### PR TITLE
feat(document): complete Epic 1 - Document Domain Implementation

### DIFF
--- a/packages/core/document/src/lib/entities/Fragment.spec.ts
+++ b/packages/core/document/src/lib/entities/Fragment.spec.ts
@@ -258,4 +258,22 @@ describe('Fragment', () => {
       );
     });
   });
+
+  describe('childCount', () => {
+    it('returns 0 for empty fragment', () => {
+      const fragment = Fragment.empty<Node>();
+      expect(fragment.childCount).toBe(0);
+    });
+
+    it('returns number of children', () => {
+      const nodeType = new NodeType('paragraph', {}, {});
+      const nodes = [
+        new Node(nodeType, {}),
+        new Node(nodeType, {}),
+        new Node(nodeType, {}),
+      ];
+      const fragment = Fragment.from(nodes);
+      expect(fragment.childCount).toBe(3);
+    });
+  });
 });

--- a/packages/core/document/src/lib/entities/Fragment.ts
+++ b/packages/core/document/src/lib/entities/Fragment.ts
@@ -15,7 +15,13 @@ export class Fragment<TNode extends Node> {
     return new Fragment<TNode>([...nodes]); // Defensive copy
   }
 
+  get childCount(): number {
+    return this.content.length;
+  }
+
   get size(): number {
+    // TODO: EPIC 2'de Node.nodeSize implementasyonundan sonra güncelle
+    // Şimdilik childCount ile aynı (tree traversal için yeterli)
     return this.content.length;
   }
 

--- a/packages/core/document/src/lib/interfaces/SchemaSpec.ts
+++ b/packages/core/document/src/lib/interfaces/SchemaSpec.ts
@@ -1,5 +1,7 @@
 export interface NodeSpec {
   attrs?: Record<string, unknown>;
+  inline?: boolean;
+  marks?: string;
 }
 
 export interface MarkSpec {

--- a/packages/core/document/src/lib/value-objects/ContentMatch.spec.ts
+++ b/packages/core/document/src/lib/value-objects/ContentMatch.spec.ts
@@ -5,8 +5,15 @@ import { Fragment } from '../entities/Fragment';
 import { Edge } from '../interfaces/Edge';
 
 // Test Helpers
-function createMockNodeType(name = 'paragraph'): NodeType {
-  return new NodeType(name, {}, { attrs: { content: 'text*' } });
+function createMockNodeType(
+  name = 'paragraph',
+  options: { inline?: boolean } = {}
+): NodeType {
+  return new NodeType(
+    name,
+    {},
+    { attrs: { content: 'text*' }, inline: options.inline }
+  );
 }
 
 function createMockContentMatch(
@@ -375,6 +382,26 @@ describe('ContentMatch', () => {
     it('returns false when other is null', () => {
       const match = createMockContentMatch();
       expect(match.equals(null as never)).toBe(false);
+    });
+  });
+
+  describe('defaultType', () => {
+    it('returns null when edges array is empty', () => {
+      const match = new ContentMatch(true, []);
+      expect(match.defaultType()).toBeNull();
+    });
+
+    it("returns first edge's type when edges exist", () => {
+      const typeA = createMockNodeType('heading');
+      const typeB = createMockNodeType('paragraph');
+      const nextMatch = new ContentMatch(true, []);
+      const edges = [
+        { type: typeA, next: nextMatch },
+        { type: typeB, next: nextMatch },
+      ];
+      const match = new ContentMatch(false, edges);
+
+      expect(match.defaultType()).toBe(typeA);
     });
   });
 });

--- a/packages/core/document/src/lib/value-objects/ContentMatch.ts
+++ b/packages/core/document/src/lib/value-objects/ContentMatch.ts
@@ -119,6 +119,10 @@ export class ContentMatch {
     return true;
   }
 
+  defaultType(): NodeType | null {
+    return this.edges.length > 0 ? this.edges[0].type : null;
+  }
+
   private validateParameters(validEnd: boolean, edges: Edge[]): void {
     if (validEnd === null) {
       throw new Error('ContentMatch validEnd cannot be null');

--- a/packages/core/document/src/lib/value-objects/NodeType.spec.ts
+++ b/packages/core/document/src/lib/value-objects/NodeType.spec.ts
@@ -1,4 +1,5 @@
 import { NodeSpec } from '../interfaces/SchemaSpec';
+import { MarkType } from './MarkType';
 import { NodeType } from './NodeType';
 
 describe('NodeType', () => {
@@ -131,6 +132,72 @@ describe('NodeType', () => {
       expect(() => nodeType.equals(null as never)).toThrow(
         'NodeType equals parameter cannot be null'
       );
+    });
+  });
+
+  describe('allowsMarkType', () => {
+    const mockSchema = {} as never;
+
+    it('given null parameter, throws error', () => {
+      const nodeType = new NodeType('paragraph', mockSchema, {});
+      expect(() => nodeType.allowsMarkType(null as never)).toThrow(
+        'NodeType allowsMarkType parameter cannot be null'
+      );
+    });
+
+    it('given non-MarkType parameter, throws error', () => {
+      const nodeType = new NodeType('paragraph', mockSchema, {});
+      expect(() => nodeType.allowsMarkType('bold' as never)).toThrow(
+        'NodeType allowsMarkType parameter must be MarkType'
+      );
+    });
+
+    it('given marks spec is undefined, returns true when inline is true', () => {
+      const nodeType = new NodeType('text', mockSchema, { inline: true });
+      const boldType = new MarkType('bold', mockSchema, {});
+      expect(nodeType.allowsMarkType(boldType)).toBe(true);
+    });
+
+    it('given marks spec is undefined, returns false when inline is false', () => {
+      const nodeType = new NodeType('paragraph', mockSchema, { inline: false });
+      const boldType = new MarkType('bold', mockSchema, {});
+      expect(nodeType.allowsMarkType(boldType)).toBe(false);
+    });
+
+    it('given marks spec is undefined, returns false when inline is undefined', () => {
+      const nodeType = new NodeType('paragraph', mockSchema, {});
+      const boldType = new MarkType('bold', mockSchema, {});
+      expect(nodeType.allowsMarkType(boldType)).toBe(false);
+    });
+
+    it('given marks spec is "_", returns true for any mark type', () => {
+      const nodeType = new NodeType('paragraph', mockSchema, { marks: '_' });
+      const boldType = new MarkType('bold', mockSchema, {});
+      const linkType = new MarkType('link', mockSchema, {});
+      expect(nodeType.allowsMarkType(boldType)).toBe(true);
+      expect(nodeType.allowsMarkType(linkType)).toBe(true);
+    });
+
+    it('given marks spec is "", returns false for any mark type', () => {
+      const nodeType = new NodeType('code_block', mockSchema, { marks: '' });
+      const boldType = new MarkType('bold', mockSchema, {});
+      expect(nodeType.allowsMarkType(boldType)).toBe(false);
+    });
+
+    it('given marks spec is space-separated list, returns true for listed mark', () => {
+      const nodeType = new NodeType('paragraph', mockSchema, {
+        marks: 'bold italic',
+      });
+      const boldType = new MarkType('bold', mockSchema, {});
+      expect(nodeType.allowsMarkType(boldType)).toBe(true);
+    });
+
+    it('given marks spec is space-separated list, returns false for unlisted mark', () => {
+      const nodeType = new NodeType('paragraph', mockSchema, {
+        marks: 'bold italic',
+      });
+      const linkType = new MarkType('link', mockSchema, {});
+      expect(nodeType.allowsMarkType(linkType)).toBe(false);
     });
   });
 });

--- a/packages/core/document/src/lib/value-objects/NodeType.ts
+++ b/packages/core/document/src/lib/value-objects/NodeType.ts
@@ -1,4 +1,5 @@
 import { NodeSpec } from '../interfaces/SchemaSpec';
+import { MarkType } from './MarkType';
 
 export class NodeType {
   readonly name: string;
@@ -16,16 +17,50 @@ export class NodeType {
   }
 
   equals(other: NodeType): boolean {
-    if(other === null) {
+    if (other === null) {
       throw new Error('NodeType equals parameter cannot be null');
     }
 
     return this.name === other.name;
   }
 
+  allowsMarkType(markType: MarkType): boolean {
+    if (markType === null) {
+      throw new Error('NodeType allowsMarkType parameter cannot be null');
+    }
+
+    if (!(markType instanceof MarkType)) {
+      throw new Error('NodeType allowsMarkType parameter must be MarkType');
+    }
+
+    const marks = this.spec.marks;
+
+    // marks tanımsız → inline ise tümüne izin, değilse hiçbirine
+    if (marks === undefined) {
+      return this.spec.inline === true;
+    }
+
+    // "_" → tüm marklara izin
+    if (marks === '_') {
+      return true;
+    }
+
+    // "" → hiçbir marka izin yok
+    if (marks === '') {
+      return false;
+    }
+
+    // "bold italic link" → listedekilere izin
+    const allowedMarks = marks.split(' ');
+    return allowedMarks.includes(markType.name);
+  }
+
   private validateParameter(paramName: string, paramValue: unknown): void {
     if (paramName === 'name') {
-      if (!paramValue || (typeof paramValue === 'string' && paramValue.trim() === '')) {
+      if (
+        !paramValue ||
+        (typeof paramValue === 'string' && paramValue.trim() === '')
+      ) {
         throw new Error(`NodeType ${paramName} cannot be empty`);
       }
 


### PR DESCRIPTION
- Add NodeType.allowsMarkType() for mark validation
- Add NodeSpec.marks field for mark permission configuration
- Add Fragment.childCount getter (rename from size semantic)
- Remove ContentMatch.allowsMark() (moved to NodeType)
- Update Fragment.size with TODO for nodeSize implementation

Issue #11
Closes Epic #1