### PR TITLE
feat(document): implement Fragment.findIndex() (closes #29)

### DIFF
--- a/packages/core/document/src/lib/entities/Fragment.spec.ts
+++ b/packages/core/document/src/lib/entities/Fragment.spec.ts
@@ -338,4 +338,76 @@ describe('Fragment', () => {
       );
     });
   });
+
+  describe('findIndex', () => {
+    it('given pos is 0, returns index 0 and offset 0', () => {
+      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+        text: 'First',
+      });
+
+      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+        text: 'Second',
+      });
+
+      const fragment = Fragment.from([node1, node2]);
+
+      const result = fragment.findIndex(0);
+
+      expect(result).toEqual({ index: 0, offset: 0 });
+    });
+  });
+
+  it('given pos equals size, returns index childCount and offset size', () => {
+    const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      text: 'First',
+    });
+
+    const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      text: 'Second',
+    });
+
+    const fragment = Fragment.from([node1, node2]);
+
+    const result = fragment.findIndex(fragment.size);
+
+    expect(result).toEqual({
+      index: fragment.childCount,
+      offset: fragment.size,
+    });
+  });
+
+  it('given pos inside first child, returns index 0 and offset 0', () => {
+    const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      text: 'First',
+    });
+
+    const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      text: 'Second',
+    });
+
+    const fragment = Fragment.from([node1, node2]);
+
+    const result = fragment.findIndex(1);
+
+    expect(result).toEqual({ index: 0, offset: 0 });
+  });
+
+  it('given negative pos, throws RangeError', () => {
+    const fragment = Fragment.empty<Node>();
+
+    expect(() => fragment.findIndex(-1)).toThrow(
+      'Invalid position: -1 (size: 0)'
+    );
+  });
+
+  it('given pos greater than size, throws RangeError', () => {
+    const node = new Node(new NodeType('paragraph', mockSchema, spec), {
+      text: 'First',
+    });
+    const fragment = Fragment.from([node]);
+
+    expect(() => fragment.findIndex(100)).toThrow(
+      'Invalid position: 100 (size: 2)'
+    );
+  });
 });

--- a/packages/core/document/src/lib/entities/Fragment.ts
+++ b/packages/core/document/src/lib/entities/Fragment.ts
@@ -20,7 +20,7 @@ export class Fragment<TNode extends Node> {
   }
 
   get size(): number {
-    return this.content.reduce((sum, node) => sum += node.nodeSize, 0);
+    return this.content.reduce((sum, node) => (sum += node.nodeSize), 0);
   }
 
   get firstChild(): TNode | undefined {
@@ -63,6 +63,33 @@ export class Fragment<TNode extends Node> {
 
     if (this.content.length !== other.content.length) return false;
 
-    return this.content.every((node, index) => node.equals(other.content[index]));
+    return this.content.every((node, index) =>
+      node.equals(other.content[index])
+    );
+  }
+
+  findIndex(pos: number): { index: number; offset: number } {
+    if (pos < 0 || pos > this.size) {
+      throw new RangeError(`Invalid position: ${pos} (size: ${this.size})`);
+    }
+
+    if (pos == 0) {
+      return { index: 0, offset: 0 };
+    }
+
+    if (pos == this.size) {
+      return { index: this.childCount, offset: this.size };
+    }
+
+    let i = 0,
+      curPos = 0;
+    while (i < this.content.length) {
+      const end = curPos + this.content[i].nodeSize;
+      if (end > pos) return { index: i, offset: curPos };
+      curPos = end;
+      i++;
+    }
+
+    return { index: i, offset: curPos };
   }
 }


### PR DESCRIPTION
- Add findIndex(pos) method returning { index, offset }
- Throws RangeError for negative or out-of-bounds positions

Issue #29