### PR TITLE
feat(document): implement Attribute class and hasRequiredAttrs() (clo…

### DIFF
--- a/packages/core/document/src/index.ts
+++ b/packages/core/document/src/index.ts
@@ -6,12 +6,17 @@ export { Node } from './lib/entities/Node';
 
 // Interfaces
 export type { Edge } from './lib/interfaces/Edge';
-export type { NodeSpec, MarkSpec } from './lib/interfaces/SchemaSpec';
+export type {
+  AttributeSpec,
+  NodeSpec,
+  MarkSpec,
+} from './lib/interfaces/SchemaSpec';
 
 // Sevices
 export { SchemaService } from './lib/services/SchemaService';
 
 // Value Objects
+export { Attribute } from './lib/value-objects/Attribute';
 export { ContentMatch } from './lib/value-objects/ContentMatch';
 export { NodeRange } from './lib/value-objects/NodeRange';
 export { NodeType } from './lib/value-objects/NodeType';

--- a/packages/core/document/src/lib/interfaces/Attributespec.ts
+++ b/packages/core/document/src/lib/interfaces/Attributespec.ts
@@ -1,0 +1,4 @@
+export interface AttributeSpec {
+  default?: unknown;
+  validate?: (value: unknown) => void;
+}

--- a/packages/core/document/src/lib/interfaces/SchemaSpec.ts
+++ b/packages/core/document/src/lib/interfaces/SchemaSpec.ts
@@ -1,5 +1,5 @@
 export interface NodeSpec {
-  attrs?: Record<string, unknown>;
+  attrs?: Record<string, AttributeSpec>;
   inline?: boolean;
   marks?: string;
   leaf?: boolean;
@@ -8,4 +8,9 @@ export interface NodeSpec {
 
 export interface MarkSpec {
   attrs?: Record<string, unknown>;
+}
+
+export interface AttributeSpec {
+  default?: unknown;
+  validate?: (value: unknown) => void;
 }

--- a/packages/core/document/src/lib/value-objects/Attribute.spec.ts
+++ b/packages/core/document/src/lib/value-objects/Attribute.spec.ts
@@ -1,0 +1,37 @@
+import { Attribute } from './Attribute';
+
+describe('Attribute', () => {
+  describe('constructor', () => {
+    it('giben valid spec, creates Attribute instance', () => {
+      const spec = {};
+      const attribute = new Attribute(spec);
+      expect(attribute).toBeInstanceOf(Attribute);
+    });
+
+    it('given spec with default, sets hasDefault to true', () => {
+      const spec = { default: 'defaultValue' };
+      const attribute = new Attribute(spec);
+      expect(attribute.hasDefault).toBe(true);
+    });
+
+    it('given spec null, throws error', () => {
+      expect(() => new Attribute(null as never)).toThrow(
+        'Attribute spec cannot be null'
+      );
+    });
+
+    it('given spec undefined, throws error', () => {
+      expect(() => new Attribute(undefined as never)).toThrow(
+        'Attribute spec cannot be undefined'
+      );
+    });
+  });
+
+  describe('isRequired', () => {
+    it('given spec without default key, returns true', () => {
+      const spec = {};
+      const attribute = new Attribute(spec);
+      expect(attribute.isRequired).toBe(true);
+    });
+  });
+});

--- a/packages/core/document/src/lib/value-objects/Attribute.ts
+++ b/packages/core/document/src/lib/value-objects/Attribute.ts
@@ -1,0 +1,25 @@
+import { AttributeSpec } from "../interfaces/SchemaSpec";
+
+export class Attribute {
+  readonly hasDefault: boolean;
+  constructor(public spec: AttributeSpec) {
+    this.validateParameter('spec', spec);
+    this.hasDefault = Object.prototype.hasOwnProperty.call(spec, 'default');
+  }
+
+  get isRequired(): boolean {
+    return !this.hasDefault;
+  }
+
+  private validateParameter(
+    parameterName: string,
+    parameterValue: unknown
+  ): void {
+    if (parameterValue === null) {
+      throw new Error(`Attribute ${parameterName} cannot be null`);
+    }
+    if (parameterValue === undefined) {
+      throw new Error(`Attribute ${parameterName} cannot be undefined`);
+    }
+  }
+}

--- a/packages/core/document/src/lib/value-objects/ContentMatch.spec.ts
+++ b/packages/core/document/src/lib/value-objects/ContentMatch.spec.ts
@@ -12,7 +12,7 @@ function createMockNodeType(
   return new NodeType(
     name,
     {},
-    { attrs: { content: 'text*' }, inline: options.inline }
+    { attrs: { content: { default: 'text*' } }, inline: options.inline }
   );
 }
 

--- a/packages/core/document/src/lib/value-objects/NodeType.spec.ts
+++ b/packages/core/document/src/lib/value-objects/NodeType.spec.ts
@@ -27,7 +27,7 @@ describe('NodeType', () => {
     });
 
     it('constructor, given valid spec, stores spec', () => {
-      const spec: NodeSpec = { attrs: { level: 1 } };
+      const spec: NodeSpec = { attrs: { level: { default: 1 } } };
       const mockSchema = {} as never;
 
       const nodeType = new NodeType('paragraph', mockSchema, spec);
@@ -36,7 +36,7 @@ describe('NodeType', () => {
     });
 
     it('given default, is null', () => {
-      const spec: NodeSpec = { attrs: { level: 1 } };
+      const spec: NodeSpec = { attrs: { level: { default: 1 } } };
       const mockSchema = {} as never;
 
       const nodeType = new NodeType('paragraph', mockSchema, spec);
@@ -45,7 +45,7 @@ describe('NodeType', () => {
     });
 
     it('given default, is null', () => {
-      const spec: NodeSpec = { attrs: { level: 1 } };
+      const spec: NodeSpec = { attrs: { level: { default: 1 } } };
       const mockSchema = {} as never;
 
       const nodeType = new NodeType('paragraph', mockSchema, spec);
@@ -136,7 +136,7 @@ describe('NodeType', () => {
     it('equals, given different name, returns false', () => {
       const mockSchema = {} as never;
       const spec1: NodeSpec = { attrs: {} };
-      const spec2: NodeSpec = { attrs: { level: 1 } };
+      const spec2: NodeSpec = { attrs: { level: { default: 1 } } };
 
       const nodeType1 = new NodeType('paragraph', mockSchema, spec1);
       const nodeType2 = new NodeType('heading', mockSchema, spec2);
@@ -323,16 +323,6 @@ describe('NodeType', () => {
     });
   });
 
-  describe('hasRequiredAttrs()', () => {
-    it('given current attrs system without required concept, returns false', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: { level: 1 } };
-      const nodeType = new NodeType('heading', mockSchema, spec);
-
-      expect(nodeType.hasRequiredAttrs()).toBe(false);
-    });
-  });
-
   describe('validContent()', () => {
     it('given matching content, returns true', () => {
       const mockSchema = {} as never;
@@ -404,6 +394,22 @@ describe('NodeType', () => {
       expect(() => nodeType.validContent(undefined as never)).toThrow(
         'NodeType validContent parameter cannot be undefined'
       );
+    });
+  });
+
+  describe('hasRequiredAttrs()', () => {
+    it('given one attr without default, returns true', () => {
+      const mockSchema = {} as never;
+      const spec: NodeSpec = {
+        attrs: {
+          title: { default: 'Untitled' },
+          level: {},
+        },
+      };
+
+      const nodeType = new NodeType('heading', mockSchema, spec);
+
+      expect(nodeType.hasRequiredAttrs()).toBe(true);
     });
   });
 });

--- a/packages/core/document/src/lib/value-objects/NodeType.ts
+++ b/packages/core/document/src/lib/value-objects/NodeType.ts
@@ -1,6 +1,7 @@
 import { Fragment } from '../entities/Fragment';
 import { Node } from '../entities/Node';
 import { NodeSpec } from '../interfaces/SchemaSpec';
+import { Attribute } from './Attribute';
 import { ContentMatch } from './ContentMatch';
 import { Mark } from './Mark';
 import { MarkType } from './MarkType';
@@ -9,6 +10,7 @@ export class NodeType {
   readonly name: string;
   readonly schema: unknown;
   readonly spec: NodeSpec;
+  readonly attrs: Record<string, Attribute>;
 
   contentMatch: ContentMatch | null = null;
   inlineContent: boolean | null = null;
@@ -17,6 +19,13 @@ export class NodeType {
     this.validateParameter('name', name);
     this.validateParameter('schema', schema);
     this.validateParameter('spec', spec);
+
+    this.attrs = {};
+    if (spec.attrs) {
+      for (const [attrName, attrSpec] of Object.entries(spec.attrs)) {
+        this.attrs[attrName] = new Attribute(attrSpec);
+      }
+    }
 
     this.name = name;
     this.schema = schema;
@@ -94,6 +103,11 @@ export class NodeType {
   }
 
   hasRequiredAttrs(): boolean {
+    for (const attr of Object.values(this.attrs)) {
+      if (attr.isRequired) {
+        return true;
+      }
+    }
     return false;
   }
 


### PR DESCRIPTION
…ses #33)

- Add AttributeSpec interface to SchemaSpec.ts
- Add Attribute value object with hasDefault, defaultValue, isRequired
- Update NodeType.attrs to Record<string, Attribute>
- Implement hasRequiredAttrs() with real Attribute-based logic
- Update NodeSpec.attrs type to Record<string, AttributeSpec>
- Fix NodeType.spec.ts attrs to use AttributeSpec format
- Fix ContentMatch.spec.ts createMockNodeType attrs
- Export Attribute and AttributeSpec from index.ts

Issue #33