### PR TITLE
feat(document): implement NodeType.createAndFill() and Fragment.appen…

### DIFF
--- a/packages/core/document/src/lib/entities/Fragment.spec.ts
+++ b/packages/core/document/src/lib/entities/Fragment.spec.ts
@@ -1,9 +1,14 @@
+import { Mark } from '../value-objects/Mark';
 import { NodeType } from '../value-objects/NodeType';
 import { Fragment } from './Fragment';
 import { Node } from './Node';
 
 const mockSchema = {} as never;
 const spec = { attrs: {} };
+
+function createMarks(...types: string[]): Mark<Record<string, unknown>>[] {
+  return types.map((type) => new Mark(type, {}));
+}
 
 describe('Fragment', () => {
   describe('creation', () => {
@@ -488,6 +493,90 @@ describe('Fragment', () => {
       expect(result.childCount).toBe(1);
       expect(result.child(0).content.childCount).toBe(1);
       expect(result.child(0).content.child(0)).toBe(child1);
+    });
+  });
+
+  describe('append', () => {
+    it('given other empty, returns this', () => {
+      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+
+      const fragment = Fragment.from([node1]);
+
+      const result = fragment.append(Fragment.empty<Node>());
+
+      expect(result).toBe(fragment);
+    });
+
+    it('given this empty, returns other', () => {
+      const empty = Fragment.empty<Node>();
+      const other = Fragment.from([
+        new Node(new NodeType('paragraph', mockSchema, spec), {}),
+      ]);
+
+      const result = empty.append(other);
+
+      expect(result).toBe(other);
+    });
+
+    it('given both non-empty fragments, returns new fragment with all children', () => {
+      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const node3 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const node4 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+
+      const fragment1 = Fragment.from([node1, node2]);
+      const fragment2 = Fragment.from([node3, node4]);
+
+      const result = fragment1.append(fragment2);
+
+      expect(Fragment.from([node1, node2, node3, node4]).equals(result)).toBe(
+        true
+      );
+    });
+
+    it('given last child of this and first child of other are text nodes with same marks, merges them into single node', () => {
+      const textType = new NodeType('text', mockSchema, { text: true });
+      const node1 = new Node(textType, {}, undefined, undefined, 'Hello ');
+      const node2 = new Node(textType, {}, undefined, undefined, 'World');
+
+      const fragment1 = Fragment.from([node1]);
+      const fragment2 = Fragment.from([node2]);
+
+      const result = fragment1.append(fragment2);
+      const expected = Fragment.from([
+        new Node(textType, {}, undefined, undefined, 'Hello World'),
+      ]);
+
+      expect(expected.equals(result)).toBe(true);
+    });
+
+    it('given last child of this and first child of other are text nodes with different marks, keeps them separate', () => {
+      const textType = new NodeType('text', mockSchema, { text: true });
+      const node1 = new Node(
+        textType,
+        {},
+        undefined,
+        createMarks('bold'),
+        'Hello '
+      );
+      const node2 = new Node(
+        textType,
+        {},
+        undefined,
+        createMarks('italic'),
+        'World'
+      );
+
+      const fragment1 = Fragment.from([node1]);
+      const fragment2 = Fragment.from([node2]);
+
+      const result = fragment1.append(fragment2);
+      const expected = Fragment.from([
+        new Node(textType, {}, undefined, createMarks('bold'), 'Hello '),
+        new Node(textType, {}, undefined, createMarks('italic'), 'World'),
+      ]);
+
+      expect(expected.equals(result)).toBe(true);
     });
   });
 });

--- a/packages/core/document/src/lib/entities/Fragment.ts
+++ b/packages/core/document/src/lib/entities/Fragment.ts
@@ -1,3 +1,4 @@
+import { deepEqual } from '../utils/deep-equal';
 import { Node } from './Node';
 
 export class Fragment<TNode extends Node> {
@@ -124,5 +125,29 @@ export class Fragment<TNode extends Node> {
     }
 
     return Fragment.from(result);
+  }
+
+  append(other: Fragment<TNode>): Fragment<TNode> {
+    if (!other.size) return this;
+    if (!this.size) return other;
+    if (this.lastChild?.type === other.firstChild?.type) {
+      const last = this.lastChild;
+      const first = other.firstChild;
+      if (last && first && last.type.isText && first.type.isText && deepEqual(last.marks, first.marks)) {
+        const merged = new Node(
+          last.type,
+          last.attrs,
+          Fragment.empty(),
+          last.marks,
+          `${last.text}${first.text}`
+        ) as TNode;
+        return Fragment.from([
+          ...this.content.slice(0, -1),
+          merged,
+          ...other.content.slice(1),
+        ]);
+      }
+    }
+    return Fragment.from([...this.content, ...other.content]);
   }
 }

--- a/packages/core/document/src/lib/interfaces/Attributespec.ts
+++ b/packages/core/document/src/lib/interfaces/Attributespec.ts
@@ -1,4 +1,0 @@
-export interface AttributeSpec {
-  default?: unknown;
-  validate?: (value: unknown) => void;
-}

--- a/packages/core/document/src/lib/value-objects/NodeType.spec.ts
+++ b/packages/core/document/src/lib/value-objects/NodeType.spec.ts
@@ -412,4 +412,69 @@ describe('NodeType', () => {
       expect(nodeType.hasRequiredAttrs()).toBe(true);
     });
   });
+
+  describe('createAndFill()', () => {
+    it('given text node type, throws error', () => {
+      const mockSchema = {} as never;
+      const spec: NodeSpec = { attrs: {}, text: true };
+      const nodeType = new NodeType('text', mockSchema, spec);
+
+      expect(() => nodeType.createAndFill()).toThrow(
+        'NodeType.createAndFill cannot construct text nodes'
+      );
+    });
+
+    it('given content that cannot be filled, returns null', () => {
+      const paragraphType = new NodeType('paragraph', {} as never, {
+        attrs: {},
+      });
+      const headingType = new NodeType('heading', {} as never, { attrs: {} });
+
+      const finalMatch = new ContentMatch(true, []);
+      const match = new ContentMatch(false, [
+        { type: paragraphType, next: finalMatch },
+      ]);
+
+      const nodeType = new NodeType('doc', {} as never, { attrs: {} });
+      nodeType.contentMatch = match;
+
+      const content = Fragment.from([new Node(headingType, {})]);
+      const result = nodeType.createAndFill({}, content);
+
+      expect(result).toBe(null);
+    });
+
+    it('given empty content and valid contentMatch, returns node', () => {
+      const nodeType = new NodeType('doc', {} as never, { attrs: {} });
+      nodeType.contentMatch = new ContentMatch(true, []);
+
+      const result = nodeType.createAndFill();
+
+      expect(result).toBeInstanceOf(Node);
+    });
+
+    it('given non-empty content that needs fill, returns node with complete content', () => {
+      const paragraphType = new NodeType('paragraph', {} as never, {
+        attrs: {},
+      });
+      const headingType = new NodeType('heading', {} as never, { attrs: {} });
+
+      const finalMatch = new ContentMatch(true, []);
+      const match2 = new ContentMatch(false, [
+        { type: paragraphType, next: finalMatch },
+      ]);
+      const match1 = new ContentMatch(false, [
+        { type: headingType, next: match2 },
+      ]);
+
+      const nodeType = new NodeType('doc', {} as never, { attrs: {} });
+      nodeType.contentMatch = match1;
+
+      const content = Fragment.from([new Node(paragraphType, {})]);
+      const result = nodeType.createAndFill({}, content);
+
+      expect(result).toBeInstanceOf(Node);
+      expect(result?.content.childCount).toBe(2);
+    });
+  });
 });

--- a/packages/core/document/src/lib/value-objects/NodeType.ts
+++ b/packages/core/document/src/lib/value-objects/NodeType.ts
@@ -102,6 +102,31 @@ export class NodeType {
     return new Node(this, attrs || {}, nodes, marks || []);
   }
 
+  createAndFill(
+    attrs?: Record<string, unknown>,
+    content?: Fragment<Node> | Node[],
+    marks?: Mark[]
+  ): Node | null {
+    if (this.isText)
+      throw new Error('NodeType.createAndFill cannot construct text nodes');
+
+    let nodes = Array.isArray(content)
+      ? Fragment.from(content)
+      : content ?? Fragment.empty<Node>();
+
+    if (nodes.size) {
+      const before = this.contentMatch?.fillBefore(nodes);
+      if (!before) return null;
+      nodes = before.append(nodes);
+    }
+
+    const matched = this.contentMatch?.matchFragment(nodes);
+    const after = matched && matched.fillBefore(Fragment.empty(), true);
+    if (!after) return null;
+
+    return new Node(this, attrs || {}, nodes.append(after), marks || []);
+  }
+
   hasRequiredAttrs(): boolean {
     for (const attr of Object.values(this.attrs)) {
       if (attr.isRequired) {


### PR DESCRIPTION
…d() (closes #34)

- Add Fragment.append() with text node merge support
- Add NodeType.createAndFill() using fillBefore/matchFragment

Issue #34