### PR TITLE
feat(document): implement ResolvedPos.static resolve() (closes #35)

### DIFF
--- a/packages/core/document/src/lib/value-objects/ResolvedPos.spec.ts
+++ b/packages/core/document/src/lib/value-objects/ResolvedPos.spec.ts
@@ -1,3 +1,4 @@
+import { Fragment } from '../entities/Fragment';
 import { Node } from '../entities/Node';
 import { NodeType } from './NodeType';
 import { ResolvedPos } from './ResolvedPos';
@@ -336,6 +337,41 @@ describe('ResolvedPos', () => {
       expect(() => a.equals(null as never)).toThrow(
         'ResolvedPos equals parameter cannot be null'
       );
+    });
+  });
+
+  describe('resolve', () => {
+    it('given pos is negative, throws RangeError', () => {
+      const rootNode = createMockNode();
+
+      expect(() => ResolvedPos.resolve(rootNode, -1)).toThrow(
+        'Position -1 out of range'
+      );
+    });
+
+    it('given pos exceeds document size, throws RangeError', () => {
+      const rootNode = createMockNode();
+
+      expect(() => ResolvedPos.resolve(rootNode, rootNode.content.size + 1)).toThrow(
+        `Position ${rootNode.content.size + 1} out of range`
+      );
+    });
+
+    it('given empty document and pos 0, returns ResolvedPos with depth 0 and parentOffset 0', () => {
+      const rootNode = createMockNode();
+      const resolvedPos = ResolvedPos.resolve(rootNode, 0);
+
+      expect(resolvedPos?.depth).toBe(0);
+      expect(resolvedPos?.parentOffset).toBe(0);
+    });
+
+    it('given document with one block child and pos inside block, returns depth 1 and parentOffset 0', () => {
+      const childNode = createMockNode();
+      const rootNode = new Node(createMockNode().type, {}, Fragment.from([childNode]));
+      const resolvedPos = ResolvedPos.resolve(rootNode, 1);
+
+      expect(resolvedPos?.depth).toBe(1);
+      expect(resolvedPos?.parentOffset).toBe(0);
     });
   });
 });

--- a/packages/core/document/src/lib/value-objects/ResolvedPos.ts
+++ b/packages/core/document/src/lib/value-objects/ResolvedPos.ts
@@ -27,6 +27,29 @@ export class ResolvedPos {
     return this.pos - (this.path[this.path.length - 1] as number);
   }
 
+  static resolve(doc: Node, pos: number): ResolvedPos {
+    if (!(pos >= 0 && pos <= doc.content.size)) {
+      throw new RangeError(`Position ${pos} out of range`);
+    }
+
+    const path: (Node | number)[] = [];
+    let start = 0,
+      parentOffset = pos;
+
+    for (let node = doc;; ) {
+      const { index, offset } = node.content.findIndex(parentOffset);
+      const rem = parentOffset - offset;
+      path.push(node, index, start + offset);
+      if (!rem) break;
+      node = node.content.child(index);
+      if (node.type.isText) break;
+      parentOffset = rem - 1;
+      start += offset + 1;
+    }
+
+    return new ResolvedPos(pos, path, parentOffset);
+  }
+
   index(depth?: number | null): number {
     const resolvedDepth = this.resolveDepth(depth);
     return this.path[resolvedDepth * 3 + 1] as number;
@@ -99,6 +122,12 @@ export class ResolvedPos {
     return this.pos < other.pos ? this : other;
   }
 
+  equals(other: ResolvedPos): boolean {
+    if (other === null)
+      throw new Error('ResolvedPos equals parameter cannot be null');
+    return this.pos === other.pos && this.doc === other.doc;
+  }
+
   private resolveDepth(depth?: number | null): number {
     if (depth === null || depth === undefined) {
       return this.depth;
@@ -109,12 +138,6 @@ export class ResolvedPos {
     }
 
     return depth;
-  }
-
-  equals(other: ResolvedPos): boolean {
-    if (other === null)
-      throw new Error('ResolvedPos equals parameter cannot be null');
-    return this.pos === other.pos && this.doc === other.doc;
   }
 
   private validateParameters(name: string, value: unknown) {


### PR DESCRIPTION
- Add static resolve() method to ResolvedPos
- Build path array via iterative descent through doc tree
- Handle text node boundary (isText break)
- Throw RangeError for out-of-range positions

Issue #35