### PR TITLE
feat(document): Mark + MarkType type-safe refactor (closes #49)

### DIFF
--- a/packages/core/document/src/lib/entities/Fragment.spec.ts
+++ b/packages/core/document/src/lib/entities/Fragment.spec.ts
@@ -1,4 +1,5 @@
 import { Mark } from '../value-objects/Mark';
+import { MarkType } from '../value-objects/MarkType';
 import { NodeType } from '../value-objects/NodeType';
 import { Fragment } from './Fragment';
 import { Node } from './Node';
@@ -6,8 +7,10 @@ import { Node } from './Node';
 const mockSchema = {} as never;
 const spec = { attrs: {} };
 
-function createMarks(...types: string[]): Mark<Record<string, unknown>>[] {
-  return types.map((type) => new Mark(type, {}));
+const createMarkType = (name: string) => new MarkType(name, {}, {});
+
+function createMarks(...types: string[]): Mark[] {
+  return types.map((type) => new Mark(createMarkType(type), {}));
 }
 
 describe('Fragment', () => {

--- a/packages/core/document/src/lib/value-objects/Mark.spec.ts
+++ b/packages/core/document/src/lib/value-objects/Mark.spec.ts
@@ -1,172 +1,213 @@
+import { MarkSpec } from '../interfaces/SchemaSpec';
 import { Mark } from './Mark';
+import { MarkType } from './MarkType';
 
-function createMark<TAttrs extends Record<string, unknown>>(
-  type: string,
-  attrs: TAttrs
-): Mark<TAttrs> {
-  return new Mark(type, attrs);
-}
+const createMarkType = (name: string, schema: unknown, spec: MarkSpec) =>
+  new MarkType(name, schema, spec);
+const boldMarkType = createMarkType('bold', {}, {});
+const italicMarkType = createMarkType('italic', {}, {});
 
-describe('Mark Value Object', () => {
-  describe('Construction', () => {
-    it('should create mark with type and attrs', () => {
-      const mark = createMark('bold', { color: 'purple' });
+const createMark = (type: MarkType, attrs: Record<string, unknown>) =>
+  new Mark(type, attrs);
 
-      expect(mark.type).toBe('bold');
+describe('Mark', () => {
+  describe('constructor', () => {
+    it('given valid MarkType and attrs, creates Mark instance', () => {
+      const mark = createMark(boldMarkType, { color: 'purple' });
+
+      expect(mark).toBeInstanceOf(Mark);
+    });
+
+    it('given valid MarkType and attrs, stores type', () => {
+      const mark = createMark(boldMarkType, { color: 'purple' });
+
+      expect(mark.type).toBe(boldMarkType);
+    });
+
+    it('given valid MarkType and attrs, stores attrs', () => {
+      const mark = createMark(boldMarkType, { color: 'purple' });
+
       expect(mark.attrs).toEqual({ color: 'purple' });
     });
 
-    it('should throw when type is null', () => {
+    it('given null type, throws error', () => {
       expect(() => createMark(null as never, {})).toThrow(
-        'Type must be a string'
+        'Type must be a MarkType instance'
       );
     });
 
-    it('should throw when type is undefined', () => {
+    it('given undefined type, throws error', () => {
       expect(() => createMark(undefined as never, {})).toThrow(
-        'Type must be a string'
+        'Type must be a MarkType instance'
       );
     });
 
-    it('should throw when attrs is null', () => {
-      expect(() => createMark('bold', null as never)).toThrow(
+    it('given null attrs, throws error', () => {
+      expect(() => createMark(boldMarkType, null as never)).toThrow(
         'Attrs must be an object'
       );
     });
 
-    it('should throw when attrs is undefined', () => {
-      expect(() => createMark('bold', undefined as never)).toThrow(
+    it('given undefined attrs, throws error', () => {
+      expect(() => createMark(boldMarkType, undefined as never)).toThrow(
         'Attrs must be an object'
       );
     });
   });
 
-  describe('Equality', () => {
-    it('should return true for marks with same type and attrs', () => {
-      const mark = createMark('bold', { color: 'purple' });
-      const mark2 = createMark('bold', { color: 'purple' });
+  describe('equals', () => {
+    it('given same type and attrs, returns true', () => {
+      const mark = createMark(boldMarkType, { color: 'purple' });
+      const mark2 = createMark(boldMarkType, { color: 'purple' });
 
       expect(mark.equals(mark2)).toBe(true);
     });
 
-    it('should throw when comparing with null', () => {
+    it('given null, throws error', () => {
       expect(() =>
-        createMark('bold', { color: 'purple' }).equals(null as never)
-      ).toThrow('Mark cannot be null or undefined');
+        createMark(boldMarkType, { color: 'purple' }).equals(null as never)
+      ).toThrow('Mark cannot be null');
     });
 
-    it('should throw when comparing with undefined', () => {
+    it('given undefined, throws error', () => {
       expect(() =>
-        createMark('bold', { color: 'purple' }).equals(undefined as never)
-      ).toThrow('Mark cannot be null or undefined');
+        createMark(boldMarkType, { color: 'purple' }).equals(undefined as never)
+      ).toThrow('Mark cannot be undefined');
     });
 
-    it('should return false for different types', () => {
-      const mark = createMark('bold', { color: 'purple' });
-      const mark2 = createMark('italic', { color: 'red' });
+    it('given different type, returns false', () => {
+      const mark = createMark(boldMarkType, { color: 'purple' });
+      const mark2 = createMark(italicMarkType, { color: 'purple' });
       expect(mark.equals(mark2)).toBe(false);
     });
 
-    it('should return false for different attrs', () => {
-      const mark = createMark('bold', { color: 'purple' });
-      const mark2 = createMark('bold', { color: 'blue' });
+    it('given different attrs, returns false', () => {
+      const mark = createMark(boldMarkType, { color: 'purple' });
+      const mark2 = createMark(boldMarkType, { color: 'red' });
       expect(mark.equals(mark2)).toBe(false);
     });
 
-    it('should return true for self comparison', () => {
-      const mark = createMark('bold', { color: 'purple' });
+    it('given self comparison, returns true', () => {
+      const mark = createMark(boldMarkType, { color: 'purple' });
       expect(mark.equals(mark)).toBe(true);
-    });
-
-    it('should handle empty attrs equality', () => {
-      expect(createMark('', {}).equals(createMark('', {}))).toBe(true);
-    });
-  });
-
-  describe('Merge', () => {
-    it('should return new mark with merged attrs for same type', () => {
-      const mark1 = createMark('link', { href: 'example.com' });
-      const mark2 = createMark('link', { title: 'Example' });
-
-      const merged = mark1.merge(mark2);
-
-      expect(merged).not.toBeNull();
-      expect(merged?.type).toBe('link');
-      expect(merged?.attrs).toEqual({ href: 'example.com', title: 'Example' });
-    });
-
-    it('should return null for different types', () => {
-      const mark1 = createMark('bold', {});
-      const mark2 = createMark('italic', {});
-
-      expect(mark1.merge(mark2)).toBeNull();
-    });
-
-    it('should override attrs with same keys', () => {
-      const mark1 = createMark('link', { href: 'old.com', title: 'Old' });
-      const mark2 = createMark('link', { href: 'new.com' });
-
-      const merged = mark1.merge(mark2);
-
-      expect(merged).not.toBeNull();
-      expect(merged?.attrs).toEqual({ href: 'new.com', title: 'Old' });
-    });
-
-    it('should throw when merging with null', () => {
-      const mark = createMark('bold', {});
-      expect(() => mark.merge(null as never)).toThrow(
-        'Mark cannot be null or undefined'
-      );
-    });
-
-    it('should throw when merging with undefined', () => {
-      const mark = createMark('bold', {});
-      expect(() => mark.merge(undefined as never)).toThrow(
-        'Mark cannot be null or undefined'
-      );
     });
   });
 
   describe('isInSet', () => {
     it('given mark is in set, returns true', () => {
-      const mark = createMark('bold', { color: 'purple' });
-      const set = [createMark('italic', { color: 'purple' }), mark];
+      const mark = createMark(boldMarkType, { color: 'purple' });
+      const set = [createMark(italicMarkType, { color: 'purple' }), mark];
 
       expect(mark.isInSet(set)).toBe(true);
     });
 
     it('given null set, throws error', () => {
-      const mark = createMark('bold', { color: 'purple' });
+      const mark = createMark(boldMarkType, { color: 'purple' });
       expect(() => mark.isInSet(null as never)).toThrow(
-        'Mark isInSet set cannot be null or undefined'
+        'Mark isInSet set cannot be null'
+      );
+    });
+
+    it('given undefined set, throws error', () => {
+      const mark = createMark(boldMarkType, { color: 'purple' });
+      expect(() => mark.isInSet(undefined as never)).toThrow(
+        'Mark isInSet set cannot be undefined'
       );
     });
   });
 
   describe('removeFromSet', () => {
     it('given mark is in set, returns new set without the mark', () => {
-      const mark = createMark('bold', { color: 'purple' });
-      const set = [createMark('italic', { color: 'purple' }), mark];
+      const mark = createMark(boldMarkType, { color: 'purple' });
+      const set = [createMark(italicMarkType, { color: 'purple' }), mark];
 
       const newSet = mark.removeFromSet(set);
 
-      expect(newSet).toEqual([createMark('italic', { color: 'purple' })]);
+      expect(newSet).toEqual([createMark(italicMarkType, { color: 'purple' })]);
     });
 
     it('given mark is not in set, returns same reference', () => {
-      const mark = createMark('bold', { color: 'purple' });
-      const set = [createMark('italic', { color: 'purple' })];
+      const mark = createMark(boldMarkType, { color: 'purple' });
+      const set = [createMark(italicMarkType, { color: 'purple' })];
 
       const newSet = mark.removeFromSet(set);
 
       expect(newSet).toBe(set);
     });
 
-    it('given null or undefined set, throws error', () => {
-      const mark = createMark('bold', { color: 'purple' });
+    it('given null set, throws error', () => {
+      const mark = createMark(boldMarkType, { color: 'purple' });
       expect(() => mark.removeFromSet(null as never)).toThrow(
-        'Mark removeFromSet set cannot be null or undefined'
+        'Mark removeFromSet set cannot be null'
       );
+    });
+
+    it('given undefined set, throws error', () => {
+      const mark = createMark(boldMarkType, { color: 'purple' });
+      expect(() => mark.removeFromSet(undefined as never)).toThrow(
+        'Mark removeFromSet set cannot be undefined'
+      );
+    });
+  });
+
+  describe('addToSet', () => {
+    it('given mark already in set, returns same reference', () => {
+      const mark = createMark(boldMarkType, { color: 'purple' });
+      const set = [mark];
+
+      const newSet = mark.addToSet(set);
+
+      expect(newSet).toBe(set);
+    });
+
+    it('given empty set, returns set with this mark', () => {
+      const mark = createMark(boldMarkType, { color: 'purple' });
+      const set: Mark[] = [];
+
+      const newSet = mark.addToSet(set);
+
+      expect(newSet).toEqual([mark]);
+    });
+
+    it('given mark with lower rank, insert before existing mark', () => {
+      const mark1 = createMark(createMarkType('strong', {}, {}), {});
+      const mark2 = createMark(createMarkType('em', {}, {}), {});
+      mark1.type.rank = 1;
+      mark2.type.rank = 2;
+
+      const set = [mark2];
+
+      const newSet = mark1.addToSet(set);
+
+      expect(newSet).toEqual([mark1, mark2]);
+    });
+
+    it('given mark excluded by existing mark, returns same reference', () => {
+      const mark1 = createMark(createMarkType('strong', {}, {}), {});
+      const mark2 = createMark(createMarkType('em', {}, {}), {});
+      mark1.type.rank = 1;
+      mark2.type.rank = 2;
+      mark2.type.excluded = [mark1.type];
+
+      const set = [mark2];
+
+      const newSet = mark1.addToSet(set);
+
+      expect(newSet).toBe(set);
+    });
+
+    it('given mark that excludes existing mark, returns set without existing mark', () => {
+      const mark1 = createMark(createMarkType('strong', {}, {}), {});
+      const mark2 = createMark(createMarkType('em', {}, {}), {});
+      mark1.type.rank = 1;
+      mark2.type.rank = 2;
+      mark1.type.excluded = [mark2.type];
+
+      const set = [mark2];
+
+      const newSet = mark1.addToSet(set);
+
+      expect(newSet).toEqual([mark1]);
     });
   });
 });

--- a/packages/core/document/src/lib/value-objects/Mark.ts
+++ b/packages/core/document/src/lib/value-objects/Mark.ts
@@ -1,91 +1,79 @@
-export class Mark<
-  TAttrs extends Record<string, unknown> = Record<string, unknown>
-> {
-  readonly type: string;
-  readonly attrs: TAttrs;
-  constructor(type: string, attrs: TAttrs) {
-    if (typeof type !== 'string') throw new Error('Type must be a string');
+import { deepEqual } from '../utils/deep-equal';
+import { MarkType } from './MarkType';
+
+export class Mark {
+  readonly type: MarkType;
+  readonly attrs: Record<string, unknown>;
+  static readonly none: readonly Mark[] = [];
+
+  constructor(type: MarkType, attrs: Record<string, unknown>) {
+    if (!(type instanceof MarkType))
+      throw new Error('Type must be a MarkType instance');
     if (typeof attrs !== 'object' || attrs === null || Array.isArray(attrs))
       throw new Error('Attrs must be an object');
 
-    this.attrs = { ...attrs } as TAttrs;
+    this.attrs = { ...attrs };
     this.type = type;
   }
 
-  /**
-   * Compares this mark with another mark for equality.
-   *
-   * Two marks are considered equal if they have the same type and
-   * equivalent attributes (shallow comparison).
-   *
-   * @param other - The mark to compare with
-   * @returns true if marks are equal, false otherwise
-   *
-   * @remarks
-   * Currently supports flat attributes only. Nested objects are compared
-   * by reference, not deep equality. Deep equality support is planned for
-   * future milestones.
-   *
-   * @example
-   * ```typescript
-   * const mark1 = new Mark('bold', { color: 'red' });
-   * const mark2 = new Mark('bold', { color: 'red' });
-   * mark1.equals(mark2); // true
-   * ```
-   */
-  equals(other: Mark<TAttrs>): boolean {
+  equals(other: Mark): boolean {
     if (!this.validateMark(other)) return false;
 
-    const thisKeys = Object.keys(this.attrs as object);
-    const otherKeys = Object.keys(other.attrs as object);
-
-    if (thisKeys.length !== otherKeys.length) {
-      return false;
-    }
-
-    return thisKeys.every((key) => {
-      return (
-        this.attrs[key as keyof TAttrs] === other.attrs[key as keyof TAttrs]
-      );
-    });
+    return deepEqual(this.attrs, other.attrs);
   }
 
-  merge<TOther extends Record<string, unknown>>(
-    other: Mark<TOther>
-  ): Mark<TAttrs & TOther> | null {
-    if (!this.validateMark(other)) return null;
-
-    const attrs = { ...this.attrs, ...other.attrs };
-
-    return new Mark(other.type, attrs);
-  }
-
-  private validateMark(other: Mark<Record<string, unknown>>): boolean {
-    if (other === null || other === undefined)
-      throw new Error('Mark cannot be null or undefined');
-
-    return this.type === other.type;
-  }
-
-  isInSet(set: readonly Mark<TAttrs>[]): boolean {
+  isInSet(set: readonly Mark[]): boolean {
     if (set === null || set === undefined) {
-      throw new Error('Mark isInSet set cannot be null or undefined');
+      throw new Error(`Mark isInSet set cannot be ${set}`);
     }
 
     return set.some((mark) => this.equals(mark));
   }
 
-  removeFromSet(set: readonly Mark<TAttrs>[]): readonly Mark<TAttrs>[] {
+  removeFromSet(set: readonly Mark[]): readonly Mark[] {
     if (set === null || set === undefined) {
-      throw new Error('Mark removeFromSet set cannot be null or undefined');
+      throw new Error(`Mark removeFromSet set cannot be ${set}`);
     }
 
     for (let i = 0; i < set.length; i++) {
       if (this.equals(set[i])) {
-        return [...set.slice(0, i), ...set.slice(i + 1)];
+        return set.slice(0, i).concat(set.slice(i + 1));
       }
     }
 
     return set;
+  }
+
+  addToSet(set: readonly Mark[]): readonly Mark[] {
+    if (set.length === 0) return [this];
+
+    let copy: Mark[] | null = null;
+
+    for (let i = 0; i < set.length; i++) {
+      if (this.equals(set[i])) return set;
+      else if (this.type.excludes(set[i].type)) {
+        if (!copy) copy = set.slice(0, i) as Mark[];
+      } else if (set[i].type.excludes(this.type)) {
+        return set;
+      } else if (set[i].type.rank > this.type.rank) {
+        if (!copy) copy = set.slice(0, i) as Mark[];
+        copy.push(this);
+        copy.push(...(set.slice(i) as Mark[]));
+        return copy;
+      } else if (copy) {
+        copy.push(set[i]);
+      }
+    }
+
+    if (!copy) copy = set.slice() as Mark[];
+    copy.push(this);
+    return copy;
+  }
+
+  private validateMark(other: Mark): boolean {
+    if (other === null || other === undefined)
+      throw new Error(`Mark cannot be ${other}`);
+
+    return this.type === other.type;
   }
 }

--- a/packages/core/document/src/lib/value-objects/MarkSet.spec.ts
+++ b/packages/core/document/src/lib/value-objects/MarkSet.spec.ts
@@ -1,8 +1,11 @@
 import { Mark } from './Mark';
 import { MarkSet } from './MarkSet';
+import { MarkType } from './MarkType';
 
-function createMarks(...types: string[]): Mark<Record<string, unknown>>[] {
-  return types.map((type) => new Mark(type, {}));
+const createMarkType = (name: string) => new MarkType(name, {}, {});
+
+function createMarks(...types: string[]): Mark[] {
+  return types.map((type) => new Mark(createMarkType(type), {}));
 }
 
 describe('MarkSet Value Object', () => {
@@ -44,7 +47,7 @@ describe('MarkSet Value Object', () => {
       const marks = createMarks('strong', 'italic');
 
       const markSet = MarkSet.from(marks);
-      marks.push(new Mark('', {}));
+      marks.push(new Mark(createMarkType('pre'), {}));
 
       expect(markSet.size).toBe(2);
     });
@@ -70,7 +73,7 @@ describe('MarkSet Value Object', () => {
     it('add, given empty markset, returns new markset with mark', () => {
       const markSet = MarkSet.empty();
 
-      const result = markSet.add(new Mark('bold', {}));
+      const result = markSet.add(new Mark(createMarkType('bold'), {}));
 
       expect(result).toBeInstanceOf(MarkSet);
     });
@@ -80,13 +83,15 @@ describe('MarkSet Value Object', () => {
 
       const markSet = MarkSet.from([mark1, mark2]);
 
-      const result = markSet.add(new Mark('underline', {}));
+      const result = markSet.add(new Mark(createMarkType('underline'), {}));
 
       expect(result).toBeInstanceOf(MarkSet);
     });
 
     it('add, given mark with same type exists, returns same instance', () => {
-      const [mark1, mark2] = createMarks('strong', 'strong');
+      const strongMarkType = createMarkType('strong');
+      const mark1 = new Mark(strongMarkType, { color: 'red' });
+      const mark2 = new Mark(strongMarkType, { color: 'blue' });
 
       const markSet = MarkSet.from([mark1]);
 
@@ -100,7 +105,7 @@ describe('MarkSet Value Object', () => {
 
       const markSet = MarkSet.from([mark1, mark2]);
 
-      markSet.add(new Mark('underline', {}));
+      markSet.add(new Mark(createMarkType('underline'), {}));
 
       expect(markSet.size).toBe(2);
     });
@@ -118,19 +123,21 @@ describe('MarkSet Value Object', () => {
       const [markStrong, markItalic] = createMarks('strong', 'italic');
       const markSet = MarkSet.from([markStrong, markItalic]);
 
-      expect(markSet.contains(new Mark('underline', {}))).toBe(false);
+      expect(markSet.contains(new Mark(createMarkType('underline'), {}))).toBe(false);
     });
 
     it('contains, given empty markset, returns false', () => {
       const markSet = MarkSet.empty();
 
-      expect(markSet.contains(new Mark('strong', { color: 'red' }))).toBe(false);
+      expect(markSet.contains(new Mark(createMarkType('strong'), { color: 'red' }))).toBe(
+        false
+      );
     });
   });
 
   describe('remove() method', () => {
     it('remove, given mark exists, returns new markset without mark', () => {
-      const mark = new Mark('strong', { color: 'red' });
+      const mark = new Mark(createMarkType('strong'), { color: 'red' });
       const markSet = MarkSet.from([mark]);
 
       const result = markSet.remove(mark);
@@ -141,7 +148,7 @@ describe('MarkSet Value Object', () => {
 
     it('remove, given mark does not exist, returns same instance', () => {
       const [markStrong, markItalic] = createMarks('strong', 'italic');
-      const markUnderline = new Mark('underline', {});
+      const markUnderline = new Mark(createMarkType('underline'), {});
 
       const markSet = MarkSet.from([markStrong, markItalic]);
 
@@ -151,7 +158,7 @@ describe('MarkSet Value Object', () => {
     });
 
     it('remove, given empty markset, returns same instance', () => {
-      const mark = new Mark('strong', { color: 'red' });
+      const mark = new Mark(createMarkType('strong'), { color: 'red' });
       const markSet = MarkSet.empty();
 
       const result = markSet.remove(mark);

--- a/packages/core/document/src/lib/value-objects/MarkType.spec.ts
+++ b/packages/core/document/src/lib/value-objects/MarkType.spec.ts
@@ -1,4 +1,5 @@
 import { MarkSpec } from '../interfaces/SchemaSpec';
+import { Mark } from './Mark';
 import { MarkType } from './MarkType';
 
 const mockSchema = {} as never;
@@ -86,6 +87,63 @@ describe('MarkType', () => {
       expect(() => markType1.equals(null as never)).toThrow(
         'MarkType equals parameter cannot be null'
       );
+    });
+  });
+
+  describe('create', () => {
+    it('given no attrrs, creates Mark with empty attrs', () => {
+      const boldMarkType = new MarkType('bold', mockSchema, spec);
+      const newMark = boldMarkType.create();
+
+      expect(newMark).toEqual(new Mark(boldMarkType, {}));
+    });
+
+    it('given attrs, creates Mark with given attrs', () => {
+      const boldMarkType = new MarkType('bold', mockSchema, spec);
+      const newMark = boldMarkType.create({ color: 'red' });
+
+      expect(newMark).toEqual(new Mark(boldMarkType, { color: 'red' }));
+    });
+  });
+
+  describe('isInSet', () => {
+    it('given mark of this type in set, returns the mark', () => {
+      const boldMarkType = new MarkType('bold', mockSchema, spec);
+      const mark1 = new Mark(boldMarkType, { color: 'red' });
+      const mark2 = new Mark(boldMarkType, { color: 'blue' });
+      const set = [mark1, mark2];
+
+      expect(boldMarkType.isInSet(set)).toBe(mark1);
+    });
+
+    it('given no mark of this type in set, returns undefined', () => {
+      const boldMarkType = new MarkType('bold', mockSchema, spec);
+      const italicMarkType = new MarkType('italic', mockSchema, spec);
+      const mark1 = new Mark(italicMarkType, { color: 'red' });
+      const set = [mark1];
+
+      expect(boldMarkType.isInSet(set)).toBeUndefined();
+    });
+  });
+
+  describe('removeFromSet', () => {
+    it('given mark of this type in set, returns new set without the mark', () => {
+      const boldMarkType = new MarkType('bold', mockSchema, spec);
+      const italicMarkType = new MarkType('italic', mockSchema, spec);
+      const mark1 = new Mark(boldMarkType, { color: 'red' });
+      const mark2 = new Mark(italicMarkType, { color: 'blue' });
+      const set = [mark1, mark2];
+
+      expect(boldMarkType.removeFromSet(set)).toEqual([mark2]);
+    });
+
+    it('given no mark of this type in set, returns returns same reference', () => {
+      const boldMarkType = new MarkType('bold', mockSchema, spec);
+      const italicMarkType = new MarkType('italic', mockSchema, spec);
+      const mark1 = new Mark(italicMarkType, { color: 'red' });
+      const set = [mark1];
+
+      expect(boldMarkType.removeFromSet(set)).toBe(set);
     });
   });
 });

--- a/packages/core/document/src/lib/value-objects/MarkType.ts
+++ b/packages/core/document/src/lib/value-objects/MarkType.ts
@@ -1,9 +1,12 @@
 import { MarkSpec } from '../interfaces/SchemaSpec';
+import { Mark } from './Mark';
 
 export class MarkType {
   readonly name: string;
   readonly schema: unknown;
   readonly spec: MarkSpec;
+  excluded: readonly MarkType[] = [];
+  rank = 0;
 
   constructor(name: string, schema: unknown, spec: MarkSpec) {
     this.validateParameter('name', name);
@@ -15,12 +18,34 @@ export class MarkType {
     this.spec = spec;
   }
 
+  create(attrs?: Record<string, unknown>): Mark {
+    return new Mark(this, attrs || {});
+  }
+
+  isInSet(set: readonly Mark[]): Mark | undefined {
+    return set.find((mark) => mark.type === this);
+  }
+
+  removeFromSet(set: readonly Mark[]): readonly Mark[] {
+    for (let i = 0; i < set.length; i++) {
+      if (set[i].type === this) {
+        return set.slice(0, i).concat(set.slice(i + 1));
+      }
+    }
+
+    return set;
+  }
+
   equals(other: MarkType): boolean {
     if (other === null) {
       throw new Error('MarkType equals parameter cannot be null');
     }
 
     return this.name === other.name;
+  }
+  
+  excludes(other: MarkType): boolean {
+    return this.excluded.indexOf(other) > -1;
   }
 
   private validateParameter(paramName: string, paramValue: unknown): void {


### PR DESCRIPTION
- Mark.type: string → MarkType instance
- Remove Mark generic <TAttrs>
- Remove Mark.merge()
- Add Mark.addToSet() with rank ordering and excludes
- Add Mark.none static constant
- Add MarkType.rank and MarkType.excluded fields
- Add MarkType.create(), isInSet(), removeFromSet(), excludes()
- Update Mark.spec.ts, MarkSet.spec.ts, Fragment.spec.ts

Issue #49