### PR TITLE
feat(document): implement Node API completion

### DIFF
--- a/packages/core/document/src/lib/entities/Fragment.spec.ts
+++ b/packages/core/document/src/lib/entities/Fragment.spec.ts
@@ -1,17 +1,9 @@
-// import { Mark } from '../value-objects/Mark';
-// import { MarkType } from '../value-objects/MarkType';
 import { NodeType } from '../value-objects/NodeType';
 import { Fragment } from './Fragment';
 import { Node } from './Node';
 
 const mockSchema = {} as never;
 const spec = { attrs: {} };
-
-// const createMarkType = (name: string) => new MarkType(name, {}, {});
-
-/* function createMarks(...types: string[]): Mark[] {
-  return types.map((type) => new Mark(createMarkType(type), {}));
-} */
 
 describe('Fragment', () => {
   describe('creation', () => {
@@ -267,16 +259,6 @@ describe('Fragment', () => {
     });
   });
 
-  /* describe('size', () => {
-    it('given text node, returns sum of nodeSize values', () => {
-      const textType = new NodeType('text', {}, { text: true });
-      const node = new Node(textType, {}, undefined, undefined, 'Hello World');
-      const fragment = Fragment.from([node]);
-
-      expect(fragment.size).toBe(11);
-    });
-  }); */
-
   describe('childCount', () => {
     it('returns 0 for empty fragment', () => {
       const fragment = Fragment.empty<Node>();
@@ -469,17 +451,6 @@ describe('Fragment', () => {
       expect(result.child(0)).toBe(node1);
     });
 
-    /* it('given range cutting into text node, returns trimmed text node', () => {
-      const textType = new NodeType('text', mockSchema, { text: true });
-      const node = new Node(textType, {}, undefined, undefined, 'Hello World');
-      const fragment = Fragment.from([node]);
-
-      const result = fragment.cut(6, 11);
-
-      expect(result.childCount).toBe(1);
-      expect(result.child(0).text).toBe('World');
-    }); */
-
     it('given range cutting into non-text node, returns trimmed node', () => {
       const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
       const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
@@ -536,50 +507,30 @@ describe('Fragment', () => {
         true
       );
     });
+  });
 
-    /* it('given last child of this and first child of other are text nodes with same marks, merges them into single node', () => {
-      const textType = new NodeType('text', mockSchema, { text: true });
-      const node1 = new Node(textType, {}, undefined, undefined, 'Hello ');
-      const node2 = new Node(textType, {}, undefined, undefined, 'World');
+  describe('maybeChild()', () => {
+    it('given valid index, returns child node', () => {
+      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+        text: 'First',
+      });
+      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+        text: 'Second',
+      });
 
-      const fragment1 = Fragment.from([node1]);
-      const fragment2 = Fragment.from([node2]);
+      const fragment = Fragment.from([node1, node2]);
 
-      const result = fragment1.append(fragment2);
-      const expected = Fragment.from([
-        new Node(textType, {}, undefined, undefined, 'Hello World'),
-      ]);
+      expect(fragment.maybeChild(0)).toBe(node1);
+    });
 
-      expect(expected.equals(result)).toBe(true);
-    }); */
+    it('given invalid index, returns null', () => {
+      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+        text: 'First',
+      });
 
-    /* it('given last child of this and first child of other are text nodes with different marks, keeps them separate', () => {
-      const textType = new NodeType('text', mockSchema, { text: true });
-      const node1 = new Node(
-        textType,
-        {},
-        undefined,
-        createMarks('bold'),
-        'Hello '
-      );
-      const node2 = new Node(
-        textType,
-        {},
-        undefined,
-        createMarks('italic'),
-        'World'
-      );
+      const fragment = Fragment.from([node1]);
 
-      const fragment1 = Fragment.from([node1]);
-      const fragment2 = Fragment.from([node2]);
-
-      const result = fragment1.append(fragment2);
-      const expected = Fragment.from([
-        new Node(textType, {}, undefined, createMarks('bold'), 'Hello '),
-        new Node(textType, {}, undefined, createMarks('italic'), 'World'),
-      ]);
-
-      expect(expected.equals(result)).toBe(true);
-    }); */
+      expect(fragment.maybeChild(-1)).toBeNull();
+    });
   });
 });

--- a/packages/core/document/src/lib/entities/Fragment.ts
+++ b/packages/core/document/src/lib/entities/Fragment.ts
@@ -1,4 +1,3 @@
-// import { deepEqual } from '../utils/deep-equal';
 import { Node } from './Node';
 
 export class Fragment<TNode extends Node> {
@@ -106,17 +105,6 @@ export class Fragment<TNode extends Node> {
         const end = pos + child.nodeSize;
         if (end > from) {
           if (pos < from || end > to) {
-            /* if (child.type.isText) {
-              child = child.cut(
-                Math.max(0, from - pos),
-                Math.min(child.text?.length ?? 0, to - pos)
-              ) as TNode;
-            } else {
-              child = child.cut(
-                Math.max(0, from - pos - 1),
-                Math.min(child.content.size, to - pos - 1)
-              ) as TNode;
-            } */
             child = child.cut(
               Math.max(0, from - pos - 1),
               Math.min(child.content.size, to - pos - 1)
@@ -134,24 +122,13 @@ export class Fragment<TNode extends Node> {
   append(other: Fragment<TNode>): Fragment<TNode> {
     if (!other.size) return this;
     if (!this.size) return other;
-    /* if (this.lastChild?.type === other.firstChild?.type) {
-      const last = this.lastChild;
-      const first = other.firstChild;
-      if (last && first && last.type.isText && first.type.isText && deepEqual(last.marks, first.marks)) {
-        const merged = new Node(
-          last.type,
-          last.attrs,
-          Fragment.empty(),
-          last.marks,
-          `${last.text}${first.text}`
-        ) as TNode;
-        return Fragment.from([
-          ...this.content.slice(0, -1),
-          merged,
-          ...other.content.slice(1),
-        ]);
-      }
-    } */
+
     return Fragment.from([...this.content, ...other.content]);
+  }
+
+  maybeChild(index: number): TNode | null {
+    if (index < 0 || index >= this.content.length) return null;
+
+    return this.content[index];
   }
 }

--- a/packages/core/document/src/lib/entities/Node.spec.ts
+++ b/packages/core/document/src/lib/entities/Node.spec.ts
@@ -1,12 +1,24 @@
 import { Node } from './Node';
 import { NodeType } from '../value-objects/NodeType';
 import { Fragment } from './Fragment';
+import { MarkSpec } from '../interfaces/SchemaSpec';
+import { MarkType } from '../value-objects/MarkType';
+import { Mark } from '../value-objects/Mark';
+import { ContentMatch } from '../value-objects/ContentMatch';
+import { ResolvedPos } from '../value-objects/ResolvedPos';
 
 const mockSchema = {} as never;
 const spec = { attrs: {} };
 const type = new NodeType('paragraph', mockSchema, spec);
 const mockChildNode = new Node(type, { attrs: {}, text: true });
 const mockContent = Fragment.from<Node>([mockChildNode]);
+
+const createMarkType = (name: string, schema: unknown, spec: MarkSpec) =>
+  new MarkType(name, schema, spec);
+const boldMarkType = createMarkType('bold', {}, {});
+const italicMarkType = createMarkType('italic', {}, {});
+const createMark = (type: MarkType, attrs: Record<string, unknown>) =>
+  new Mark(type, attrs);
 
 describe('Node', () => {
   describe('constructor', () => {
@@ -34,12 +46,6 @@ describe('Node', () => {
       );
     });
 
-    /* it('given null content, throws error', () => {
-      expect(() => new Node(type, {}, null as never)).toThrow(
-        'Node content cannot be null'
-      );
-    }); */
-
     it('given null marks, throws error', () => {
       const childNode = new Node(type, {});
       const mockContent = Fragment.from<Node>([childNode]);
@@ -48,24 +54,6 @@ describe('Node', () => {
         'Node marks cannot be null'
       );
     });
-
-    /* it('given null text, throws error', () => {
-      const childNode = new Node(type, {});
-      const mockContent = Fragment.from<Node>([childNode]);
-
-      expect(() => new Node(type, {}, mockContent, [], null as never)).toThrow(
-        'Node text cannot be null'
-      );
-    }); */
-
-    /* it('given empty text, throws error', () => {
-      const childNode = new Node(type, {});
-      const mockContent = Fragment.from<Node>([childNode]);
-
-      expect(() => new Node(type, {}, mockContent, [], '')).toThrow(
-        'Node text cannot be empty'
-      );
-    }); */
   });
 
   describe('childCount', () => {
@@ -89,17 +77,6 @@ describe('Node', () => {
 
       expect(node.nodeSize).toBe(1);
     });
-
-    /* it('given text node, returns text.length', () => {
-      const textType = new NodeType('text', mockSchema, { text: true });
-      const childNode = new Node(type, {});
-      const mockContent = Fragment.from<Node>([childNode]);
-
-      const text = 'Hello';
-      const node = new Node(textType, {}, mockContent, [], text);
-
-      expect(node.nodeSize).toBe(text.length);
-    }); */
 
     it('given container node, returns 2 + content.size', () => {
       const paragraphType = new NodeType('paragraph', mockSchema, spec);
@@ -129,70 +106,9 @@ describe('Node', () => {
 
       expect(node1.equals(node2)).toBe(true);
     });
-
-    /* it('given text nodes with different text, returns false', () => {
-      const node1 = new Node(
-        type,
-        { level: 1, visible: true },
-        mockContent,
-        [],
-        'Hello'
-      );
-      const node2 = new Node(
-        type,
-        { level: 1, visible: true },
-        mockContent,
-        [],
-        'World'
-      );
-
-      expect(node1.equals(node2)).toBe(false);
-    }); */
-
-    /* it('given null, throws error', () => {
-      const node = new Node(
-        type,
-        { level: 1, visible: true },
-        mockContent,
-        [],
-        'Hello'
-      );
-
-      expect(() => node.equals(null as never)).toThrow(
-        'Node equals parameter cannot be null'
-      );
-    }); */
-
-    /* it('given undefined, throws error', () => {
-      const node = new Node(
-        type,
-        { level: 1, visible: true },
-        mockContent,
-        [],
-        'Hello'
-      );
-
-      expect(() => node.equals(undefined as never)).toThrow(
-        'Node equals parameter cannot be undefined'
-      );
-    }); */
   });
 
   describe('copy', () => {
-    /* it('given same content, returns same node', () => {
-      const node = new Node(
-        type,
-        { level: 1, visible: true },
-        mockContent,
-        [],
-        'Hello'
-      );
-
-      const copy = node.copy(mockContent);
-
-      expect(copy).toBe(node);
-    }); */
-
     it('given different content, returns new node with same type/attrs/marks/', () => {
       const node = new Node(type, { level: 1, visible: true }, mockContent, []);
 
@@ -217,22 +133,6 @@ describe('Node', () => {
       expect(cut).toBe(node);
     });
 
-    /* it('given text node full range, returns this', () => {
-      const textType = new NodeType('text', mockSchema, { text: true });
-      const node = new Node(textType, {}, undefined, undefined, 'Hello');
-
-      expect(node.cut(0, 5)).toBe(node);
-    }); */
-
-    /* it('given text node partial range, returns trimmed text node', () => {
-      const textType = new NodeType('text', mockSchema, { text: true });
-      const node = new Node(textType, {}, undefined, undefined, 'Hello World');
-
-      const result = node.cut(6, 11);
-
-      expect(result.text).toBe('World');
-    }); */
-
     it('given partial range, returns new node with cut content', () => {
       const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
       const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
@@ -248,6 +148,354 @@ describe('Node', () => {
 
       expect(result).not.toBe(node);
       expect(result.content.childCount).toBe(1);
+    });
+  });
+
+  describe('child', () => {
+    it('given valid index, returns child node', () => {
+      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const content = Fragment.from([child1, child2]);
+      const node = new Node(
+        new NodeType('paragraph', mockSchema, spec),
+        {},
+        content,
+        []
+      );
+
+      expect(node.child(0)).toBe(child1);
+    });
+  });
+
+  describe('maybeChild', () => {
+    it('given valid index, returns child node', () => {
+      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const content = Fragment.from([child1, child2]);
+      const node = new Node(
+        new NodeType('paragraph', mockSchema, spec),
+        {},
+        content,
+        []
+      );
+
+      expect(node.maybeChild(0)).toBe(child1);
+    });
+
+    it('given invalid index, returns null', () => {
+      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const content = Fragment.from([child1, child2]);
+      const node = new Node(
+        new NodeType('paragraph', mockSchema, spec),
+        {},
+        content,
+        []
+      );
+
+      expect(node.maybeChild(2)).toBeNull();
+    });
+  });
+
+  describe('firstChild', () => {
+    it('given non-empty content, returns first child', () => {
+      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const content = Fragment.from([child1, child2]);
+      const node = new Node(
+        new NodeType('paragraph', mockSchema, spec),
+        {},
+        content,
+        []
+      );
+
+      expect(node.firstChild).toBe(child1);
+    });
+  });
+
+  describe('lastChild', () => {
+    it('given non-empty content, returns last child', () => {
+      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const content = Fragment.from([child1, child2]);
+      const node = new Node(
+        new NodeType('paragraph', mockSchema, spec),
+        {},
+        content,
+        []
+      );
+
+      expect(node.lastChild).toBe(child2);
+    });
+  });
+
+  describe('mark', () => {
+    it('given same maerks reference, returns same reference', () => {
+      const marks = [createMark(boldMarkType, { color: 'purple' })];
+      const node = new Node(type, {}, mockContent, marks);
+
+      const newNode = node.mark(marks);
+
+      expect(newNode).toBe(node);
+    });
+
+    it('given different marks, returns new node updating marks', () => {
+      const marks = [createMark(boldMarkType, { color: 'purple' })];
+      const node = new Node(type, {}, mockContent, marks);
+
+      const newMarks = [createMark(italicMarkType, { color: 'red' })];
+      const newNode = node.mark(newMarks);
+
+      expect(newNode).not.toBe(node);
+    });
+  });
+
+  describe('hasMarkup', () => {
+    it('given matching type/attrs/marks, returns true', () => {
+      const marks = [createMark(boldMarkType, { color: 'purple' })];
+      const node = new Node(type, { level: 1 }, mockContent, marks);
+
+      expect(node.hasMarkup(type, { level: 1 }, marks)).toBe(true);
+    });
+
+    it('given non-matching type, returns false', () => {
+      const marks = [createMark(boldMarkType, { color: 'purple' })];
+      const node = new Node(type, { level: 1 }, mockContent, marks);
+
+      const otherType = new NodeType('heading', mockSchema, spec);
+
+      expect(node.hasMarkup(otherType, { level: 1 }, marks)).toBe(false);
+    });
+  });
+
+  describe('forEach', () => {
+    it('given non-empty content, calls callback with each child node/offset/index', () => {
+      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const content = Fragment.from([child1, child2]);
+      const node = new Node(
+        new NodeType('paragraph', mockSchema, spec),
+        {},
+        content,
+        []
+      );
+
+      const callback = jest.fn();
+
+      node.forEach(callback);
+
+      expect(callback).toHaveBeenCalledWith(child1, 0, 0);
+      expect(callback).toHaveBeenCalledWith(child2, child1.nodeSize, 1);
+    });
+  });
+
+  describe('contentMatchAt', () => {
+    it('given valid index, returns ContentMatch for content at index', () => {
+      const nodeType = new NodeType('paragraph', mockSchema, spec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph', {
+        paragraph: nodeType,
+      });
+
+      const child1 = new Node(nodeType, {});
+      const child2 = new Node(nodeType, {});
+      const content = Fragment.from([child1, child2]);
+      const node = new Node(nodeType, {}, content, []);
+
+      const match = node.contentMatchAt(1);
+
+      expect(match).toBeInstanceOf(ContentMatch);
+    });
+
+    it('given index that fails to find content match, throws error', () => {
+      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const content = Fragment.from([child1]);
+      const node = new Node(
+        new NodeType('paragraph', mockSchema, spec),
+        {},
+        content,
+        []
+      );
+
+      expect(() => node.contentMatchAt(1)).toThrow(
+        'Called contentMatchAt on a node with invalid content'
+      );
+    });
+  });
+
+  describe('resolveNoCache', () => {
+    it('given valid pos, returns ResolvedPos', () => {
+      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const content = Fragment.from([child1, child2]);
+      const node = new Node(
+        new NodeType('paragraph', mockSchema, spec),
+        {},
+        content,
+        []
+      );
+
+      const resolvedPos = node.resolveNoCache(1);
+
+      expect(resolvedPos).toBeInstanceOf(ResolvedPos);
+    });
+  });
+
+  describe('nodeAt', () => {
+    it('given pos beyond content, returns null', () => {
+      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const content = Fragment.from([child1]);
+      const node = new Node(
+        new NodeType('paragraph', mockSchema, spec),
+        {},
+        content,
+        []
+      );
+
+      expect(node.nodeAt(node.content.size)).toBeNull();
+    });
+
+    it('given valid pos, returns node at position', () => {
+      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const content = Fragment.from([child1, child2]);
+      const node = new Node(
+        new NodeType('paragraph', mockSchema, spec),
+        {},
+        content,
+        []
+      );
+
+      expect(node.nodeAt(2)).toBe(child2);
+    });
+  });
+
+  describe('childAfter', () => {
+    it('given pos 0, returns first child with index 0 and offset 0', () => {
+      const child = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const node = new Node(
+        new NodeType('paragraph', mockSchema, spec),
+        {},
+        Fragment.from([child]),
+        []
+      );
+
+      const result = node.childAfter(0);
+
+      expect(result).toEqual({ node: child, index: 0, offset: 0 });
+    });
+
+    it('given pos at end of content, returns null node with index of last child and offset of last child end', () => {
+      const child = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const node = new Node(
+        new NodeType('paragraph', mockSchema, spec),
+        {},
+        Fragment.from([child]),
+        []
+      );
+
+      const result = node.childAfter(node.content.size);
+
+      expect(result).toEqual({ node: null, index: 1, offset: child.nodeSize });
+    });
+  });
+
+  describe('childBefore', () => {
+    it('given pos 0, returns null node with index 0 and offset 0', () => {
+      const child = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const node = new Node(
+        new NodeType('paragraph', mockSchema, spec),
+        {},
+        Fragment.from([child]),
+        []
+      );
+
+      const result = node.childBefore(0);
+
+      expect(result).toEqual({ node: null, index: 0, offset: 0 });
+    });
+
+    it('given pos at boundary, returns previous child with index of previous child and offset of previous child start', () => {
+      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const node = new Node(
+        new NodeType('paragraph', mockSchema, spec),
+        {},
+        Fragment.from([child1, child2]),
+        []
+      );
+
+      const result = node.childBefore(child1.nodeSize);
+
+      expect(result).toEqual({ node: child1, index: 0, offset: 0 });
+    });
+  });
+
+  describe('type delegates getter', () => {
+    it('given block node, isBlock returns true', () => {
+      const blockType = new NodeType('paragraph', mockSchema, spec);
+      const node = new Node(blockType, {}, mockContent, []);
+
+      expect(node.isBlock).toBe(true);
+    });
+
+    it('given inline node, isInline returns true', () => {
+      const node = new Node(
+        new NodeType('span', mockSchema, { inline: true }),
+        {},
+        mockContent,
+        []
+      );
+
+      expect(node.isInline).toBe(true);
+    });
+
+    it('given text node, isText returns true', () => {
+      const node = new Node(
+        new NodeType('text', mockSchema, { inline: true, text: true }),
+        {},
+        mockContent,
+        []
+      );
+
+      expect(node.isText).toBe(true);
+    });
+
+    it('given leaf node, isLeaf returns true', () => {
+      const node = new Node(
+        new NodeType('image', mockSchema, { leaf: true }),
+        {},
+        mockContent,
+        []
+      );
+
+      expect(node.isLeaf).toBe(true);
+    });
+
+    it('given atom node, isAtom returns true', () => {
+      const node = new Node(
+        new NodeType('mention', mockSchema, { atom: true }),
+        {},
+        mockContent,
+        []
+      );
+
+      expect(node.isAtom).toBe(true);
+    });
+
+    it('given textblock node, isTextblock returns true', () => {
+      const nodeType = new NodeType('p', mockSchema, spec);
+      nodeType.inlineContent = true;
+      const node = new Node(nodeType, {}, mockContent, []);
+
+      expect(node.isTextblock).toBe(true);
+    });
+
+    it('given node with inlineContent set, inlineContent returns value', () => {
+      const nodeType = new NodeType('p', mockSchema, spec);
+      nodeType.inlineContent = true;
+      const node = new Node(nodeType, {}, mockContent, []);
+
+      expect(node.inlineContent).toBe(true);
     });
   });
 });

--- a/packages/core/document/src/lib/entities/Node.ts
+++ b/packages/core/document/src/lib/entities/Node.ts
@@ -1,6 +1,8 @@
 import { deepEqual } from '../utils/deep-equal';
+import { ContentMatch } from '../value-objects/ContentMatch';
 import { Mark } from '../value-objects/Mark';
 import { NodeType } from '../value-objects/NodeType';
+import { ResolvedPos } from '../value-objects/ResolvedPos';
 import { Fragment } from './Fragment';
 
 export class Node<TAttrs = Record<string, unknown>> {
@@ -8,14 +10,12 @@ export class Node<TAttrs = Record<string, unknown>> {
   readonly attrs: TAttrs;
   readonly content: Fragment<Node>;
   readonly marks: Mark[];
-  // readonly text: string | undefined;
 
   constructor(
     type: NodeType,
     attrs: TAttrs,
     content?: Fragment<Node>,
-    marks?: Mark[],
-    /* text?: string */
+    marks?: Mark[]
   ) {
     if (type === null) {
       throw new Error('Node type cannot be null');
@@ -33,27 +33,14 @@ export class Node<TAttrs = Record<string, unknown>> {
       throw new Error('Node attrs cannot be undefined');
     }
 
-    /* if (content === null) {
-      throw new Error('Node content cannot be null');
-    } */
-
     if (marks === null) {
       throw new Error('Node marks cannot be null');
     }
-
-    /* if (text === null) {
-      throw new Error('Node text cannot be null');
-    } */
-
-    /* if (typeof text === 'string' && text.trim() === '') {
-      throw new Error('Node text cannot be empty');
-    } */
 
     this.type = type;
     this.attrs = attrs;
     this.content = content || Fragment.empty<Node>();
     this.marks = marks || [];
-    // this.text = text;
   }
 
   get childCount(): number {
@@ -65,11 +52,43 @@ export class Node<TAttrs = Record<string, unknown>> {
       return 1;
     }
 
-    /* if (this.type.isText && this.text) {
-      return this.text.length;
-    } */
-
     return 2 + this.content.size;
+  }
+
+  get firstChild(): Node | undefined {
+    return this.content.firstChild;
+  }
+
+  get lastChild(): Node | undefined {
+    return this.content.lastChild;
+  }
+
+  get isBlock(): boolean {
+    return this.type.isBlock;
+  }
+
+  get isInline(): boolean {
+    return this.type.isInline;
+  }
+
+  get isText(): boolean {
+    return this.type.isText;
+  }
+
+  get isLeaf(): boolean {
+    return this.type.isLeaf;
+  }
+
+  get isAtom(): boolean {
+    return this.type.isAtom;
+  }
+
+  get isTextblock(): boolean {
+    return this.type.isTextblock;
+  }
+
+  get inlineContent(): boolean | null {
+    return this.type.inlineContent;
   }
 
   equals(other: Node): boolean {
@@ -77,8 +96,6 @@ export class Node<TAttrs = Record<string, unknown>> {
 
     if (other === undefined)
       throw new Error('Node equals parameter cannot be undefined');
-
-    // if (this.text !== other.text) return false;
 
     return (
       this === other ||
@@ -97,26 +114,81 @@ export class Node<TAttrs = Record<string, unknown>> {
   }
 
   cut(from: number, to: number = this.content.size): Node<TAttrs> {
-    /* if (this.type.isText) {
-      if (from === 0 && to === this.text?.length) return this;
-      return new Node(
-        this.type,
-        this.attrs,
-        this.content,
-        this.marks,
-        this.text?.slice(from, to)
-      );
-    } */
-
     if (from === 0 && to === this.content.size) return this;
     return this.copy(this.content.cut(from, to));
   }
 
-  private sameMarkup(other: Node): boolean {
+  child(index: number): Node {
+    return this.content.child(index);
+  }
+
+  maybeChild(index: number): Node | null {
+    return this.content.maybeChild(index);
+  }
+
+  mark(marks: Mark[]): Node<TAttrs> {
+    if (marks === this.marks) return this;
+    return new Node(this.type, this.attrs, this.content, marks);
+  }
+
+  sameMarkup(other: Node): boolean {
+    return this.hasMarkup(other.type, other.attrs, other.marks);
+  }
+
+  hasMarkup(
+    type: NodeType,
+    attrs?: Record<string, unknown>,
+    marks?: readonly Mark[]
+  ): boolean {
     return (
-      this.type === other.type &&
-      deepEqual(this.attrs, other.attrs) &&
-      deepEqual(this.marks, other.marks)
+      this.type === type &&
+      deepEqual(this.attrs, attrs ?? {}) &&
+      Mark.sameSet(this.marks, marks ?? Mark.none)
     );
+  }
+
+  forEach(callback: (node: Node, offset: number, index: number) => void): void {
+    let offset = 0;
+    this.content.forEach((child, index) => {
+      callback(child, offset, index);
+      offset += child.nodeSize;
+    });
+  }
+
+  contentMatchAt(index: number): ContentMatch {
+    const match = this.type.contentMatch?.matchFragment(this.content, 0, index);
+
+    if (!match) {
+      throw new Error('Called contentMatchAt on a node with invalid content');
+    }
+
+    return match;
+  }
+
+  resolveNoCache(pos: number): ResolvedPos {
+    return ResolvedPos.resolve(this as Node, pos);
+  }
+
+  nodeAt(pos: number): Node | null {
+    for (let node: Node | null = this as Node; ; ) {
+      const { index, offset } = node.content.findIndex(pos);
+      node = node.content.maybeChild(index);
+      if (!node) return null;
+      if (offset === pos || node.type.isText) return node;
+      pos -= offset + 1;
+    }
+  }
+
+  childAfter(pos: number): { node: Node | null; index: number; offset: number } {
+    const { index, offset } = this.content.findIndex(pos);
+    return {
+      node: this.content.maybeChild(index),
+      index,
+      offset,
+    };
+  }
+
+  childBefore(pos: number): { node: Node | null; index: number; offset: number } {
+    return pos == 0 ? { node: null, index: 0, offset: 0 } : this.childAfter(pos - 1);
   }
 }

--- a/packages/core/document/src/lib/entities/TextNode.ts
+++ b/packages/core/document/src/lib/entities/TextNode.ts
@@ -52,7 +52,7 @@ export class TextNode extends Node {
     return new TextNode(this.type, this.attrs, text, this.marks);
   }
 
-  mark(marks: Mark[]): TextNode {
+  override mark(marks: Mark[]): TextNode {
     if (this.marks === marks) {
       return this;
     }

--- a/packages/core/document/src/lib/interfaces/SchemaSpec.ts
+++ b/packages/core/document/src/lib/interfaces/SchemaSpec.ts
@@ -5,6 +5,7 @@ export interface SchemaSpec {
 }
 
 export interface NodeSpec {
+  atom?: boolean;
   content?: string;
   attrs?: Record<string, AttributeSpec>;
   inline?: boolean;

--- a/packages/core/document/src/lib/value-objects/Mark.spec.ts
+++ b/packages/core/document/src/lib/value-objects/Mark.spec.ts
@@ -210,4 +210,42 @@ describe('Mark', () => {
       expect(newSet).toEqual([mark1]);
     });
   });
+
+  describe('sameSet()', () => {
+    it('given equal sets, returns true', () => {
+      const marks1 = [
+        createMark(boldMarkType, { color: 'purple' }),
+        createMark(italicMarkType, { color: 'purple' }),
+      ];
+      const marks2 = [
+        createMark(boldMarkType, { color: 'purple' }),
+        createMark(italicMarkType, { color: 'purple' }),
+      ];
+
+      expect(Mark.sameSet(marks1, marks2)).toBe(true);
+    });
+
+    it('given sets of different length, returns false', () => {
+      const marks1 = [createMark(boldMarkType, { color: 'purple' })];
+      const marks2 = [
+        createMark(boldMarkType, { color: 'purple' }),
+        createMark(italicMarkType, { color: 'purple' }),
+      ];
+
+      expect(Mark.sameSet(marks1, marks2)).toBe(false);
+    });
+
+    it('given sets same length but different marks, returns false', () => {
+      const marks1 = [
+        createMark(boldMarkType, { color: 'purple' }),
+        createMark(italicMarkType, { color: 'purple' }),
+      ];
+      const marks2 = [
+        createMark(italicMarkType, { color: 'blue' }),
+        createMark(italicMarkType, { color: 'purple' }),
+      ];
+
+      expect(Mark.sameSet(marks1, marks2)).toBe(false);
+    });
+  });
 });

--- a/packages/core/document/src/lib/value-objects/Mark.ts
+++ b/packages/core/document/src/lib/value-objects/Mark.ts
@@ -16,6 +16,17 @@ export class Mark {
     this.type = type;
   }
 
+
+  static sameSet(a: readonly Mark[], b: readonly Mark[]): boolean {
+    if (a.length !== b.length) return false;
+
+    for (let i = 0; i < a.length; i++) {
+      if (!a[i].equals(b[i])) return false;
+    }
+
+    return true;
+  }
+
   equals(other: Mark): boolean {
     if (!this.validateMark(other)) return false;
 

--- a/packages/core/document/src/lib/value-objects/NodeType.spec.ts
+++ b/packages/core/document/src/lib/value-objects/NodeType.spec.ts
@@ -413,6 +413,35 @@ describe('NodeType', () => {
     });
   });
 
+  describe('isTextblock()', () => {
+    it('given block node with inlineContent true, returns true', () => {
+      const mockSchema = {} as never;
+      const spec: NodeSpec = { attrs: {} };
+      const nodeType = new NodeType('paragraph', mockSchema, spec);
+      nodeType.inlineContent = true;
+
+      expect(nodeType.isTextblock).toBe(true);
+    });
+  });
+
+  describe('isAtom()', () => {
+    it('given leaf node, returns true', () => {
+      const mockSchema = {} as never;
+      const spec: NodeSpec = { attrs: {}, leaf: true };
+      const nodeType = new NodeType('image', mockSchema, spec);
+
+      expect(nodeType.isAtom).toBe(true);
+    });
+
+    it('given non-leaf node with atom spec true, returns true', () => {
+      const mockSchema = {} as never;
+      const spec: NodeSpec = { attrs: {}, atom: true };
+      const nodeType = new NodeType('image', mockSchema, spec);
+
+      expect(nodeType.isAtom).toBe(true);
+    });
+  });
+
   describe('createAndFill()', () => {
     it('given text node type, throws error', () => {
       const mockSchema = {} as never;

--- a/packages/core/document/src/lib/value-objects/NodeType.ts
+++ b/packages/core/document/src/lib/value-objects/NodeType.ts
@@ -88,6 +88,14 @@ export class NodeType {
     return !this.isBlock;
   }
 
+  get isTextblock(): boolean {
+    return this.isBlock && this.inlineContent === true;
+  }
+
+  get isAtom(): boolean {
+    return this.isLeaf || this.spec.atom === true;
+  }
+
   create(
     attrs?: Record<string, unknown>,
     content?: Fragment<Node> | Node[],


### PR DESCRIPTION
- Add childAfter(pos) and childBefore(pos) methods
- Add isBlock, isInline, isText, isLeaf, isAtom, isTextblock, inlineContent delegate getters
- Add child(index), maybeChild(index), firstChild, lastChild accessors
- Add mark(marks), hasMarkup(type, attrs?, marks?), sameMarkup(other) public methods
- Add forEach(callback), contentMatchAt(index), resolveNoCache(pos), nodeAt(pos)
- Add Fragment.maybeChild(index)
- Add Mark.sameSet(a, b)
- Add NodeType.isTextblock, NodeType.isAtom
- Add NodeSpec.atom

Issue #53