### PR TITLE
feat(document): implement Fragment API completion and forEach fix

### DIFF
--- a/packages/core/document/src/lib/entities/Fragment.spec.ts
+++ b/packages/core/document/src/lib/entities/Fragment.spec.ts
@@ -1,6 +1,7 @@
 import { NodeType } from '../value-objects/NodeType';
 import { Fragment } from './Fragment';
 import { Node } from './Node';
+import { TextNode } from './TextNode';
 
 const mockSchema = {} as never;
 const spec = { attrs: {} };
@@ -129,23 +130,6 @@ describe('Fragment', () => {
       expect(visited).toEqual([node1, node2, node3]);
     });
 
-    it('passes index to callback', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
-        text: 'First',
-      });
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
-        text: 'Second',
-      });
-      const fragment = Fragment.from([node1, node2]);
-
-      const indces: number[] = [];
-      fragment.forEach((node, index) => {
-        indces.push(index);
-      });
-
-      expect(indces).toEqual([0, 1]);
-    });
-
     it('does nothing for empty fragment', () => {
       const fragment = Fragment.empty<Node>();
 
@@ -155,6 +139,21 @@ describe('Fragment', () => {
       });
 
       expect(visited).toEqual([]);
+    });
+
+    it('given non-empty content, calls callback with node offset and index', () => {
+      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+        text: 'First',
+      });
+      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+        text: 'Second',
+      });
+      const content = Fragment.from([node1, node2]);
+
+      const callback = jest.fn();
+      content.forEach(callback);
+
+      expect(callback).toHaveBeenCalledWith(node1, 0, 0);
     });
   });
 
@@ -507,6 +506,19 @@ describe('Fragment', () => {
         true
       );
     });
+
+    it('given two fragments ending and starting with same-markup text nodes, merges them', () => {
+      const textType = new NodeType('text', mockSchema, { text: true });
+      const text1 = new TextNode(textType, {}, 'Hello');
+      const text2 = new TextNode(textType, {}, ' World');
+
+      const frag1 = Fragment.from([text1]);
+      const frag2 = Fragment.from([text2]);
+
+      const result = frag1.append(frag2);
+
+      expect(result.childCount).toBe(1);
+    });
   });
 
   describe('maybeChild()', () => {
@@ -531,6 +543,168 @@ describe('Fragment', () => {
       const fragment = Fragment.from([node1]);
 
       expect(fragment.maybeChild(-1)).toBeNull();
+    });
+  });
+
+  describe('nodesBetween()', () => {
+    it('given range covering all children, visits all nodes', () => {
+      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+        text: 'First',
+      });
+      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+        text: 'Second',
+      });
+
+      const fragment = Fragment.from([node1, node2]);
+
+      const visited: Node[] = [];
+      fragment.nodesBetween(0, fragment.size, (node) => {
+        visited.push(node);
+      });
+
+      expect(visited).toEqual([node1, node2]);
+    });
+
+    it("given callback returning false, does not descend into that node's children", () => {
+      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+        text: 'Child 1',
+      });
+      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+        text: 'Child 2',
+      });
+      const parent = new Node(
+        new NodeType('paragraph', mockSchema, spec),
+        {},
+        Fragment.from([child1, child2]),
+        []
+      );
+      const fragment = Fragment.from([parent]);
+
+      const visited: Node[] = [];
+      fragment.nodesBetween(0, fragment.size, (node) => {
+        visited.push(node);
+        return false;
+      });
+
+      expect(visited).toEqual([parent]);
+    });
+  });
+
+  describe('descendants()', () => {
+    it('given non-empty fragment, visits all descendant nodes', () => {
+      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+        text: 'Child 1',
+      });
+      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+        text: 'Child 2',
+      });
+      const parent = new Node(
+        new NodeType('paragraph', mockSchema, spec),
+        {},
+        Fragment.from([child1, child2]),
+        []
+      );
+      const fragment = Fragment.from([parent]);
+
+      const visited: Node[] = [];
+      fragment.descendants((node) => {
+        visited.push(node);
+      });
+
+      expect(visited).toEqual([parent, child1, child2]);
+    });
+  });
+
+  describe('textBetween()', () => {
+    it('given text nodes in range, returns concatenated text', () => {
+      const textNode1 = new TextNode(
+        new NodeType('text', mockSchema, { text: true }),
+        {},
+        'Hello'
+      );
+      const textNode2 = new TextNode(
+        new NodeType('text', mockSchema, { text: true }),
+        {},
+        'World'
+      );
+      const fragment = Fragment.from([textNode1, textNode2]);
+
+      const result = fragment.textBetween(0, fragment.size);
+
+      expect(result).toBe('HelloWorld');
+    });
+
+    it('given block separator, inserts separator between blocks', () => {
+      const textType = new NodeType('text', mockSchema, { text: true });
+      const paraType = new NodeType('paragraph', mockSchema, spec);
+
+      const text1 = new TextNode(textType, {}, 'Hello');
+      const text2 = new TextNode(textType, {}, 'World');
+
+      const para1 = new Node(paraType, {}, Fragment.from([text1]), []);
+      const para2 = new Node(paraType, {}, Fragment.from([text2]), []);
+
+      const fragment = Fragment.from([para1, para2]);
+
+      expect(fragment.textBetween(0, fragment.size, '\n')).toBe('Hello\nWorld');
+    });
+
+    it('given leaf node with leafText, includes leaf text', () => {
+      const imageType = new NodeType('image', mockSchema, { leaf: true });
+      const fragment = Fragment.from([new Node(imageType, {})]);
+
+      expect(fragment.textBetween(0, fragment.size, null, '[image]')).toBe(
+        '[image]'
+      );
+    });
+  });
+
+  describe('replaceChild()', () => {
+    it('given valid index and new node, returns new fragment with replaced child', () => {
+      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const newNode = new Node(new NodeType('heading', mockSchema, spec), {});
+
+      const fragment = Fragment.from([node1, node2]);
+      const result = fragment.replaceChild(0, newNode);
+
+      expect(result.child(0)).toBe(newNode);
+    });
+
+    it('given same node at index, returns same reference', () => {
+      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const fragment = Fragment.from([node1]);
+
+      expect(fragment.replaceChild(0, node1)).toBe(fragment);
+    });
+  });
+
+  describe('addToStart', () => {
+    it('given a node, returns new fragment with node prepended', () => {
+      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const fragment = Fragment.from([node2]);
+
+      expect(fragment.addToStart(node1).child(0)).toBe(node1);
+    });
+  });
+
+  describe('addToEnd', () => {
+    it('given a node, returns new fragment with node appended', () => {
+      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const fragment = Fragment.from([node1]);
+
+      expect(fragment.addToEnd(node2).child(1)).toBe(node2);
+    });
+  });
+
+  describe('toString', () => {
+    it('given non-empty fragment, returns string representation', () => {
+      const node = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const fragment = Fragment.from([node]);
+
+      expect(fragment.toString()).toBe(`<${node}>`);
     });
   });
 });

--- a/packages/core/document/src/lib/entities/Fragment.ts
+++ b/packages/core/document/src/lib/entities/Fragment.ts
@@ -40,8 +40,15 @@ export class Fragment<TNode extends Node> {
     return this.content[index];
   }
 
-  forEach(callback: (node: TNode, index: number) => void): void {
-    this.content.forEach(callback);
+  forEach(
+    callback: (node: TNode, offset: number, index: number) => void
+  ): void {
+    let offset = 0;
+    for (let i = 0; i < this.content.length; i++) {
+      const node = this.content[i];
+      callback(node, offset, i);
+      offset += node.nodeSize;
+    }
   }
 
   slice(from: number, to: number): Fragment<TNode> {
@@ -123,12 +130,120 @@ export class Fragment<TNode extends Node> {
     if (!other.size) return this;
     if (!this.size) return other;
 
-    return Fragment.from([...this.content, ...other.content]);
+    const last = this.lastChild;
+    const first = other.firstChild;
+    if (!last || !first)
+      return Fragment.from([...this.content, ...other.content]);
+    const content = this.content.slice() as TNode[];
+
+    let i = 0;
+    if (last.isText && first.isText && last.sameMarkup(first)) {
+      const lastText = last as unknown as {
+        text: string;
+        withText: (t: string) => TNode;
+      };
+      const firstText = first as unknown as { text: string };
+      content[content.length - 1] = lastText.withText(
+        lastText.text + firstText.text
+      );
+      i = 1;
+    }
+
+    for (; i < other.content.length; i++) content.push(other.content[i]);
+    return Fragment.from(content);
   }
 
   maybeChild(index: number): TNode | null {
     if (index < 0 || index >= this.content.length) return null;
 
     return this.content[index];
+  }
+
+  nodesBetween(
+    from: number,
+    to: number,
+    callback: (
+      node: TNode,
+      start: number,
+      parent: TNode | null,
+      index: number
+    ) => boolean | void,
+    nodeStart = 0,
+    parent?: TNode
+  ): void {
+    this.forEach((child, offset, index) => {
+      const end = offset + child.nodeSize;
+      if (end > from && offset < to) {
+        const start = nodeStart + offset;
+        if (
+          callback(child, start, parent ?? null, index) !== false &&
+          child.content.size
+        ) {
+          child.content.nodesBetween(
+            Math.max(0, from - offset - 1),
+            Math.min(child.content.size, to - offset - 1),
+            callback as never,
+            nodeStart + offset + 1,
+            child as TNode
+          );
+        }
+      }
+    });
+  }
+
+  descendants(
+    callback: (
+      node: TNode,
+      pos: number,
+      parent: TNode | null,
+      index: number
+    ) => boolean | void
+  ): void {
+    this.nodesBetween(0, this.size, callback as never);
+  }
+
+  textBetween(
+    from: number,
+    to: number,
+    blockSeparator?: string | null,
+    leafText?: string | null | ((leafNode: TNode) => string)
+  ): string {
+    let text = '',
+      first = true;
+    this.nodesBetween(from, to, (node, pos) => {
+      if (node.isText) {
+        text += (node as unknown as { text: string }).text.slice(
+          Math.max(from, pos) - pos,
+          to - pos
+        );
+      } else if (node.isLeaf && leafText) {
+        text += typeof leafText === 'function' ? leafText(node) : leafText;
+      }
+      if (node.isBlock && blockSeparator) {
+        if (first) first = false;
+        else text += blockSeparator;
+      }
+    });
+    return text;
+  }
+
+  replaceChild(index: number, node: TNode): Fragment<TNode> {
+    const current = this.content[index];
+    if (current === node) return this;
+    const copy = this.content.slice() as TNode[];
+    copy[index] = node;
+    return Fragment.from(copy);
+  }
+
+  addToStart(node: TNode): Fragment<TNode> {
+    return Fragment.from([node, ...this.content]);
+  }
+
+  addToEnd(node: TNode): Fragment<TNode> {
+    return Fragment.from([...this.content, node]);
+  }
+
+  toString(): string {
+    return `<${this.content.join(',')}>`;
   }
 }

--- a/packages/core/document/src/lib/entities/Node.spec.ts
+++ b/packages/core/document/src/lib/entities/Node.spec.ts
@@ -498,4 +498,13 @@ describe('Node', () => {
       expect(node.inlineContent).toBe(true);
     });
   });
+
+  describe('toString', () => {
+    // Node.spec.ts
+    it('given a node, returns string representation', () => {
+      const node = new Node(new NodeType('paragraph', mockSchema, spec), {});
+
+      expect(node.toString()).toBe('paragraph');
+    });
+  });
 });

--- a/packages/core/document/src/lib/entities/Node.ts
+++ b/packages/core/document/src/lib/entities/Node.ts
@@ -148,11 +148,7 @@ export class Node<TAttrs = Record<string, unknown>> {
   }
 
   forEach(callback: (node: Node, offset: number, index: number) => void): void {
-    let offset = 0;
-    this.content.forEach((child, index) => {
-      callback(child, offset, index);
-      offset += child.nodeSize;
-    });
+    this.content.forEach(callback);
   }
 
   contentMatchAt(index: number): ContentMatch {
@@ -179,7 +175,11 @@ export class Node<TAttrs = Record<string, unknown>> {
     }
   }
 
-  childAfter(pos: number): { node: Node | null; index: number; offset: number } {
+  childAfter(pos: number): {
+    node: Node | null;
+    index: number;
+    offset: number;
+  } {
     const { index, offset } = this.content.findIndex(pos);
     return {
       node: this.content.maybeChild(index),
@@ -188,7 +188,17 @@ export class Node<TAttrs = Record<string, unknown>> {
     };
   }
 
-  childBefore(pos: number): { node: Node | null; index: number; offset: number } {
-    return pos == 0 ? { node: null, index: 0, offset: 0 } : this.childAfter(pos - 1);
+  childBefore(pos: number): {
+    node: Node | null;
+    index: number;
+    offset: number;
+  } {
+    return pos == 0
+      ? { node: null, index: 0, offset: 0 }
+      : this.childAfter(pos - 1);
+  }
+
+  toString(): string {
+    return this.type.name;
   }
 }

--- a/packages/core/document/src/lib/entities/TextNode.spec.ts
+++ b/packages/core/document/src/lib/entities/TextNode.spec.ts
@@ -159,4 +159,14 @@ describe('TextNode', () => {
       expect(textNode1.equals(textNode2)).toBe(false);
     });
   });
+
+  describe('toString', () => {
+    // TextNode.spec.ts
+    it('given a text node, returns string representation', () => {
+      const nodeType = new NodeType('text', mockSchema, { attrs: {} });
+      const textNode = new TextNode(nodeType, {}, 'hello');
+
+      expect(textNode.toString()).toBe('"hello"');
+    });
+  });
 });

--- a/packages/core/document/src/lib/entities/TextNode.ts
+++ b/packages/core/document/src/lib/entities/TextNode.ts
@@ -33,11 +33,28 @@ export class TextNode extends Node {
       return this;
     }
 
-    return new TextNode(this.type, this.attrs, this.textBetween(from, to), this.marks);
+    return new TextNode(
+      this.type,
+      this.attrs,
+      this.textBetween(from, to),
+      this.marks
+    );
   }
 
   get textContent(): string {
     return this.text;
+  }
+
+  override toString(): string {
+    return `"${this.text}"`;
+  }
+
+  override mark(marks: Mark[]): TextNode {
+    if (this.marks === marks) {
+      return this;
+    }
+
+    return new TextNode(this.type, this.attrs, this.text, marks);
   }
 
   textBetween(from: number, to: number): string {
@@ -50,13 +67,5 @@ export class TextNode extends Node {
     }
 
     return new TextNode(this.type, this.attrs, text, this.marks);
-  }
-
-  override mark(marks: Mark[]): TextNode {
-    if (this.marks === marks) {
-      return this;
-    }
-
-    return new TextNode(this.type, this.attrs, this.text, marks);
   }
 }


### PR DESCRIPTION
- Fix Fragment.forEach signature to (node, offset, index)
- Fix Node.forEach to delegate to Fragment.forEach
- Add Fragment.nodesBetween()
- Add Fragment.descendants()
- Add Fragment.textBetween()
- Fix Fragment.append() text node merge
- Add Fragment.replaceChild()
- Add Fragment.addToStart()
- Add Fragment.addToEnd()
- Add Fragment.toString()
- Add Node.toString()
- Add TextNode.toString()

Issue #54