### PR TITLE
feat(document): complete NodeType API

### DIFF
--- a/packages/core/document/src/lib/entities/Fragment.spec.ts
+++ b/packages/core/document/src/lib/entities/Fragment.spec.ts
@@ -1,10 +1,15 @@
-import { NodeType } from '../value-objects/NodeType';
+import { ContentMatch } from '../value-objects/ContentMatch';
 import { Fragment } from './Fragment';
 import { Node } from './Node';
 import { TextNode } from './TextNode';
-
-const mockSchema = {} as never;
-const spec = { attrs: {} };
+import {
+  paragraphType,
+  textType,
+  headingType,
+  createMockNodeType,
+  defaultMockSchema,
+  createNodeSpec,
+} from '../../testing';
 
 describe('Fragment', () => {
   describe('creation', () => {
@@ -16,10 +21,10 @@ describe('Fragment', () => {
     });
 
     it('creates fragment with nodes', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node1 = new Node(paragraphType, {
         text: 'Hello',
       });
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node2 = new Node(paragraphType, {
         text: 'World',
       });
 
@@ -32,10 +37,10 @@ describe('Fragment', () => {
 
   describe('child access', () => {
     it('accesses child by valid index', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node1 = new Node(paragraphType, {
         text: 'Hello',
       });
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node2 = new Node(paragraphType, {
         text: 'World',
       });
 
@@ -47,7 +52,7 @@ describe('Fragment', () => {
 
     it('throws on negative index', () => {
       const fragment = Fragment.from([
-        new Node(new NodeType('paragraph', mockSchema, spec), {
+        new Node(paragraphType, {
           text: 'Hello',
         }),
       ]);
@@ -59,7 +64,7 @@ describe('Fragment', () => {
 
     it('throws on index >= size', () => {
       const fragment = Fragment.from([
-        new Node(new NodeType('paragraph', mockSchema, spec), {
+        new Node(paragraphType, {
           text: 'Hello',
         }),
       ]);
@@ -75,13 +80,13 @@ describe('Fragment', () => {
 
   describe('firstChild and lastChild', () => {
     it('returns first and last child', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node1 = new Node(paragraphType, {
         text: 'First',
       });
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node2 = new Node(paragraphType, {
         text: 'Middle',
       });
-      const node3 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node3 = new Node(paragraphType, {
         text: 'Last',
       });
 
@@ -99,7 +104,7 @@ describe('Fragment', () => {
     });
 
     it('returns same node when fragment has one child', () => {
-      const node = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node = new Node(paragraphType, {
         text: 'Only',
       });
       const fragment = Fragment.from([node]);
@@ -111,13 +116,13 @@ describe('Fragment', () => {
 
   describe('forEach', () => {
     it('iterates over all children', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node1 = new Node(paragraphType, {
         text: 'First',
       });
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node2 = new Node(paragraphType, {
         text: 'Second',
       });
-      const node3 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node3 = new Node(paragraphType, {
         text: 'Third',
       });
       const fragment = Fragment.from([node1, node2, node3]);
@@ -142,10 +147,10 @@ describe('Fragment', () => {
     });
 
     it('given non-empty content, calls callback with node offset and index', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node1 = new Node(paragraphType, {
         text: 'First',
       });
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node2 = new Node(paragraphType, {
         text: 'Second',
       });
       const content = Fragment.from([node1, node2]);
@@ -159,16 +164,16 @@ describe('Fragment', () => {
 
   describe('slice', () => {
     it('slices fragment with valid range', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node1 = new Node(paragraphType, {
         text: 'First',
       });
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node2 = new Node(paragraphType, {
         text: 'Second',
       });
-      const node3 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node3 = new Node(paragraphType, {
         text: 'Third',
       });
-      const node4 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node4 = new Node(paragraphType, {
         text: 'Fourth',
       });
       const fragment = Fragment.from([node1, node2, node3, node4]);
@@ -181,10 +186,10 @@ describe('Fragment', () => {
     });
 
     it('slices from start when from is 0', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node1 = new Node(paragraphType, {
         text: 'First',
       });
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node2 = new Node(paragraphType, {
         text: 'Second',
       });
       const fragment = Fragment.from([node1, node2]);
@@ -196,10 +201,10 @@ describe('Fragment', () => {
     });
 
     it('slices to end when to equals size', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node1 = new Node(paragraphType, {
         text: 'First',
       });
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node2 = new Node(paragraphType, {
         text: 'Second',
       });
       const fragment = Fragment.from([node1, node2]);
@@ -211,7 +216,7 @@ describe('Fragment', () => {
     });
 
     it('returns empty fragment when from equals to', () => {
-      const node = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node = new Node(paragraphType, {
         text: 'First',
       });
       const fragment = Fragment.from([node]);
@@ -223,7 +228,7 @@ describe('Fragment', () => {
 
     it('throws when from is negative', () => {
       const fragment = Fragment.from([
-        new Node(new NodeType('paragraph', mockSchema, spec), {
+        new Node(paragraphType, {
           text: 'First',
         }),
       ]);
@@ -235,7 +240,7 @@ describe('Fragment', () => {
 
     it('throws when to exceeds size', () => {
       const fragment = Fragment.from([
-        new Node(new NodeType('paragraph', mockSchema, spec), {
+        new Node(paragraphType, {
           text: 'First',
         }),
       ]);
@@ -247,7 +252,7 @@ describe('Fragment', () => {
 
     it('throws when from is greater than to', () => {
       const fragment = Fragment.from([
-        new Node(new NodeType('paragraph', mockSchema, spec), {
+        new Node(paragraphType, {
           text: 'First',
         }),
       ]);
@@ -265,11 +270,10 @@ describe('Fragment', () => {
     });
 
     it('returns number of children', () => {
-      const nodeType = new NodeType('paragraph', {}, {});
       const nodes = [
-        new Node(nodeType, {}),
-        new Node(nodeType, {}),
-        new Node(nodeType, {}),
+        new Node(paragraphType, {}),
+        new Node(paragraphType, {}),
+        new Node(paragraphType, {}),
       ];
       const fragment = Fragment.from(nodes);
       expect(fragment.childCount).toBe(3);
@@ -285,13 +289,13 @@ describe('Fragment', () => {
     });
 
     it('given different children, returns false', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node1 = new Node(paragraphType, {
         text: 'First',
       });
-      const node2 = new Node(new NodeType('heading', mockSchema, spec), {
+      const node2 = new Node(headingType, {
         text: 'Middle',
       });
-      const node3 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node3 = new Node(paragraphType, {
         text: 'Last',
       });
 
@@ -302,10 +306,8 @@ describe('Fragment', () => {
     });
 
     it('given structurally equal children with different refs, returns true', () => {
-      const sharedType = new NodeType('paragraph', mockSchema, spec);
-
-      const nodeA = new Node(sharedType, { text: 'Hello' });
-      const nodeB = new Node(sharedType, { text: 'Hello' });
+      const nodeA = new Node(paragraphType, { text: 'Hello' });
+      const nodeB = new Node(paragraphType, { text: 'Hello' });
 
       const fragment1 = Fragment.from([nodeA]);
       const fragment2 = Fragment.from([nodeB]);
@@ -330,11 +332,11 @@ describe('Fragment', () => {
 
   describe('findIndex', () => {
     it('given pos is 0, returns index 0 and offset 0', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node1 = new Node(paragraphType, {
         text: 'First',
       });
 
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node2 = new Node(paragraphType, {
         text: 'Second',
       });
 
@@ -347,11 +349,11 @@ describe('Fragment', () => {
   });
 
   it('given pos equals size, returns index childCount and offset size', () => {
-    const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+    const node1 = new Node(paragraphType, {
       text: 'First',
     });
 
-    const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+    const node2 = new Node(paragraphType, {
       text: 'Second',
     });
 
@@ -366,11 +368,11 @@ describe('Fragment', () => {
   });
 
   it('given pos inside first child, returns index 0 and offset 0', () => {
-    const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+    const node1 = new Node(paragraphType, {
       text: 'First',
     });
 
-    const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+    const node2 = new Node(paragraphType, {
       text: 'Second',
     });
 
@@ -390,7 +392,7 @@ describe('Fragment', () => {
   });
 
   it('given pos greater than size, throws RangeError', () => {
-    const node = new Node(new NodeType('paragraph', mockSchema, spec), {
+    const node = new Node(paragraphType, {
       text: 'First',
     });
     const fragment = Fragment.from([node]);
@@ -402,11 +404,11 @@ describe('Fragment', () => {
 
   describe('cut', () => {
     it('given full range, returns this', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node1 = new Node(paragraphType, {
         text: 'First',
       });
 
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node2 = new Node(paragraphType, {
         text: 'Second',
       });
 
@@ -418,11 +420,11 @@ describe('Fragment', () => {
     });
 
     it('given empty range (from equals to), returns empty fragment', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node1 = new Node(paragraphType, {
         text: 'First',
       });
 
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node2 = new Node(paragraphType, {
         text: 'Second',
       });
 
@@ -434,11 +436,11 @@ describe('Fragment', () => {
     });
 
     it('given partial range covering one child, returns that child', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node1 = new Node(paragraphType, {
         text: 'First',
       });
 
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node2 = new Node(paragraphType, {
         text: 'Second',
       });
 
@@ -451,10 +453,10 @@ describe('Fragment', () => {
     });
 
     it('given range cutting into non-text node, returns trimmed node', () => {
-      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
       const parent = new Node(
-        new NodeType('paragraph', mockSchema, spec),
+        paragraphType,
         {},
         Fragment.from([child1, child2]),
         []
@@ -471,7 +473,7 @@ describe('Fragment', () => {
 
   describe('append', () => {
     it('given other empty, returns this', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const node1 = new Node(paragraphType, {});
 
       const fragment = Fragment.from([node1]);
 
@@ -482,9 +484,7 @@ describe('Fragment', () => {
 
     it('given this empty, returns other', () => {
       const empty = Fragment.empty<Node>();
-      const other = Fragment.from([
-        new Node(new NodeType('paragraph', mockSchema, spec), {}),
-      ]);
+      const other = Fragment.from([new Node(paragraphType, {})]);
 
       const result = empty.append(other);
 
@@ -492,10 +492,10 @@ describe('Fragment', () => {
     });
 
     it('given both non-empty fragments, returns new fragment with all children', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const node3 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const node4 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const node1 = new Node(paragraphType, {});
+      const node2 = new Node(paragraphType, {});
+      const node3 = new Node(paragraphType, {});
+      const node4 = new Node(paragraphType, {});
 
       const fragment1 = Fragment.from([node1, node2]);
       const fragment2 = Fragment.from([node3, node4]);
@@ -508,7 +508,6 @@ describe('Fragment', () => {
     });
 
     it('given two fragments ending and starting with same-markup text nodes, merges them', () => {
-      const textType = new NodeType('text', mockSchema, { text: true });
       const text1 = new TextNode(textType, {}, 'Hello');
       const text2 = new TextNode(textType, {}, ' World');
 
@@ -523,10 +522,10 @@ describe('Fragment', () => {
 
   describe('maybeChild()', () => {
     it('given valid index, returns child node', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node1 = new Node(paragraphType, {
         text: 'First',
       });
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node2 = new Node(paragraphType, {
         text: 'Second',
       });
 
@@ -536,7 +535,7 @@ describe('Fragment', () => {
     });
 
     it('given invalid index, returns null', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node1 = new Node(paragraphType, {
         text: 'First',
       });
 
@@ -548,10 +547,10 @@ describe('Fragment', () => {
 
   describe('nodesBetween()', () => {
     it('given range covering all children, visits all nodes', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node1 = new Node(paragraphType, {
         text: 'First',
       });
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const node2 = new Node(paragraphType, {
         text: 'Second',
       });
 
@@ -566,14 +565,14 @@ describe('Fragment', () => {
     });
 
     it("given callback returning false, does not descend into that node's children", () => {
-      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const child1 = new Node(paragraphType, {
         text: 'Child 1',
       });
-      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const child2 = new Node(paragraphType, {
         text: 'Child 2',
       });
       const parent = new Node(
-        new NodeType('paragraph', mockSchema, spec),
+        paragraphType,
         {},
         Fragment.from([child1, child2]),
         []
@@ -592,14 +591,14 @@ describe('Fragment', () => {
 
   describe('descendants()', () => {
     it('given non-empty fragment, visits all descendant nodes', () => {
-      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const child1 = new Node(paragraphType, {
         text: 'Child 1',
       });
-      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const child2 = new Node(paragraphType, {
         text: 'Child 2',
       });
       const parent = new Node(
-        new NodeType('paragraph', mockSchema, spec),
+        paragraphType,
         {},
         Fragment.from([child1, child2]),
         []
@@ -617,16 +616,8 @@ describe('Fragment', () => {
 
   describe('textBetween()', () => {
     it('given text nodes in range, returns concatenated text', () => {
-      const textNode1 = new TextNode(
-        new NodeType('text', mockSchema, { text: true }),
-        {},
-        'Hello'
-      );
-      const textNode2 = new TextNode(
-        new NodeType('text', mockSchema, { text: true }),
-        {},
-        'World'
-      );
+      const textNode1 = new TextNode(textType, {}, 'Hello');
+      const textNode2 = new TextNode(textType, {}, 'World');
       const fragment = Fragment.from([textNode1, textNode2]);
 
       const result = fragment.textBetween(0, fragment.size);
@@ -635,14 +626,11 @@ describe('Fragment', () => {
     });
 
     it('given block separator, inserts separator between blocks', () => {
-      const textType = new NodeType('text', mockSchema, { text: true });
-      const paraType = new NodeType('paragraph', mockSchema, spec);
-
       const text1 = new TextNode(textType, {}, 'Hello');
       const text2 = new TextNode(textType, {}, 'World');
 
-      const para1 = new Node(paraType, {}, Fragment.from([text1]), []);
-      const para2 = new Node(paraType, {}, Fragment.from([text2]), []);
+      const para1 = new Node(paragraphType, {}, Fragment.from([text1]), []);
+      const para2 = new Node(paragraphType, {}, Fragment.from([text2]), []);
 
       const fragment = Fragment.from([para1, para2]);
 
@@ -650,8 +638,13 @@ describe('Fragment', () => {
     });
 
     it('given leaf node with leafText, includes leaf text', () => {
-      const imageType = new NodeType('image', mockSchema, { leaf: true });
-      const fragment = Fragment.from([new Node(imageType, {})]);
+      const nodeType = createMockNodeType(
+        'image',
+        defaultMockSchema,
+        createNodeSpec()
+      );
+      nodeType.contentMatch = ContentMatch.empty;
+      const fragment = Fragment.from([new Node(nodeType, {})]);
 
       expect(fragment.textBetween(0, fragment.size, null, '[image]')).toBe(
         '[image]'
@@ -661,9 +654,9 @@ describe('Fragment', () => {
 
   describe('replaceChild()', () => {
     it('given valid index and new node, returns new fragment with replaced child', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const newNode = new Node(new NodeType('heading', mockSchema, spec), {});
+      const node1 = new Node(paragraphType, {});
+      const node2 = new Node(paragraphType, {});
+      const newNode = new Node(headingType, {});
 
       const fragment = Fragment.from([node1, node2]);
       const result = fragment.replaceChild(0, newNode);
@@ -672,7 +665,7 @@ describe('Fragment', () => {
     });
 
     it('given same node at index, returns same reference', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const node1 = new Node(paragraphType, {});
       const fragment = Fragment.from([node1]);
 
       expect(fragment.replaceChild(0, node1)).toBe(fragment);
@@ -681,8 +674,8 @@ describe('Fragment', () => {
 
   describe('addToStart', () => {
     it('given a node, returns new fragment with node prepended', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const node1 = new Node(paragraphType, {});
+      const node2 = new Node(paragraphType, {});
       const fragment = Fragment.from([node2]);
 
       expect(fragment.addToStart(node1).child(0)).toBe(node1);
@@ -691,8 +684,8 @@ describe('Fragment', () => {
 
   describe('addToEnd', () => {
     it('given a node, returns new fragment with node appended', () => {
-      const node1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const node2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const node1 = new Node(paragraphType, {});
+      const node2 = new Node(paragraphType, {});
       const fragment = Fragment.from([node1]);
 
       expect(fragment.addToEnd(node2).child(1)).toBe(node2);
@@ -701,7 +694,7 @@ describe('Fragment', () => {
 
   describe('toString', () => {
     it('given non-empty fragment, returns string representation', () => {
-      const node = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const node = new Node(paragraphType, {});
       const fragment = Fragment.from([node]);
 
       expect(fragment.toString()).toBe(`<${node}>`);

--- a/packages/core/document/src/lib/entities/Node.spec.ts
+++ b/packages/core/document/src/lib/entities/Node.spec.ts
@@ -1,24 +1,24 @@
 import { Node } from './Node';
 import { NodeType } from '../value-objects/NodeType';
 import { Fragment } from './Fragment';
-import { MarkSpec } from '../interfaces/SchemaSpec';
-import { MarkType } from '../value-objects/MarkType';
-import { Mark } from '../value-objects/Mark';
 import { ContentMatch } from '../value-objects/ContentMatch';
 import { ResolvedPos } from '../value-objects/ResolvedPos';
-
-const mockSchema = {} as never;
-const spec = { attrs: {} };
-const type = new NodeType('paragraph', mockSchema, spec);
-const mockChildNode = new Node(type, { attrs: {}, text: true });
-const mockContent = Fragment.from<Node>([mockChildNode]);
-
-const createMarkType = (name: string, schema: unknown, spec: MarkSpec) =>
-  new MarkType(name, schema, spec);
-const boldMarkType = createMarkType('bold', {}, {});
-const italicMarkType = createMarkType('italic', {}, {});
-const createMark = (type: MarkType, attrs: Record<string, unknown>) =>
-  new Mark(type, attrs);
+import {
+  defaultMockSchema,
+  defaultNodeSpec,
+  paragraphType,
+  headingType,
+  spanType,
+  mentionType,
+  boldMarkType,
+  italicMarkType,
+  createMark,
+  mockChildNode,
+  mockContent,
+  textType,
+  createNodeSpec,
+  createMockNodeType,
+} from '../../testing';
 
 describe('Node', () => {
   describe('constructor', () => {
@@ -35,33 +35,31 @@ describe('Node', () => {
     });
 
     it('given attrs null, throws error', () => {
-      expect(() => new Node(type, null as never)).toThrow(
+      expect(() => new Node(paragraphType, null as never)).toThrow(
         'Node attrs cannot be null'
       );
     });
 
     it('given attrs undefined, throws error', () => {
-      expect(() => new Node(type, undefined as never)).toThrow(
+      expect(() => new Node(paragraphType, undefined as never)).toThrow(
         'Node attrs cannot be undefined'
       );
     });
 
     it('given null marks, throws error', () => {
-      const childNode = new Node(type, {});
-      const mockContent = Fragment.from<Node>([childNode]);
+      const mockContent = Fragment.from<Node>([mockChildNode]);
 
-      expect(() => new Node(type, {}, mockContent, null as never)).toThrow(
-        'Node marks cannot be null'
-      );
+      expect(
+        () => new Node(paragraphType, {}, mockContent, null as never)
+      ).toThrow('Node marks cannot be null');
     });
   });
 
   describe('childCount', () => {
     it('returns content.childCount', () => {
-      const childNode = new Node(type, {});
-      const mockContent = Fragment.from<Node>([childNode]);
+      const mockContent = Fragment.from<Node>([mockChildNode]);
 
-      const node = new Node(type, {}, mockContent, []);
+      const node = new Node(paragraphType, {}, mockContent, []);
 
       expect(node.childCount).toBe(1);
     });
@@ -69,19 +67,21 @@ describe('Node', () => {
 
   describe('nodeSize', () => {
     it('given leaf node, returns 1', () => {
-      const image = new NodeType('image', mockSchema, { leaf: true });
-      const childNode = new Node(type, {});
-      const mockContent = Fragment.from<Node>([childNode]);
+      const nodeType = createMockNodeType(
+        'image',
+        defaultMockSchema,
+        createNodeSpec()
+      );
+      nodeType.contentMatch = ContentMatch.empty;
+      const mockContent = Fragment.from<Node>([mockChildNode]);
 
-      const node = new Node(image, {}, mockContent, []);
+      const node = new Node(nodeType, {}, mockContent, []);
 
       expect(node.nodeSize).toBe(1);
     });
 
     it('given container node, returns 2 + content.size', () => {
-      const paragraphType = new NodeType('paragraph', mockSchema, spec);
-      const childNode = new Node(paragraphType, {});
-      const mockContent = Fragment.from<Node>([childNode]);
+      const mockContent = Fragment.from<Node>([mockChildNode]);
 
       const node = new Node(paragraphType, {}, mockContent, []);
 
@@ -92,13 +92,13 @@ describe('Node', () => {
   describe('equals', () => {
     it('given same type/attrs/content/marks, returns true', () => {
       const node1 = new Node(
-        type,
+        paragraphType,
         { level: 1, visible: true },
         mockContent,
         []
       );
       const node2 = new Node(
-        type,
+        paragraphType,
         { level: 1, visible: true },
         mockContent,
         []
@@ -110,9 +110,14 @@ describe('Node', () => {
 
   describe('copy', () => {
     it('given different content, returns new node with same type/attrs/marks/', () => {
-      const node = new Node(type, { level: 1, visible: true }, mockContent, []);
+      const node = new Node(
+        paragraphType,
+        { level: 1, visible: true },
+        mockContent,
+        []
+      );
 
-      const newChildNode = new Node(type, {});
+      const newChildNode = new Node(paragraphType, {});
       const newContent = Fragment.from<Node>([newChildNode]);
 
       const copy = node.copy(newContent);
@@ -126,7 +131,12 @@ describe('Node', () => {
 
   describe('cut', () => {
     it('given from 0 and to content size, returns this', () => {
-      const node = new Node(type, { level: 1, visible: true }, mockContent, []);
+      const node = new Node(
+        paragraphType,
+        { level: 1, visible: true },
+        mockContent,
+        []
+      );
 
       const cut = node.cut(0, mockContent.size);
 
@@ -134,15 +144,10 @@ describe('Node', () => {
     });
 
     it('given partial range, returns new node with cut content', () => {
-      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
       const content = Fragment.from([child1, child2]);
-      const node = new Node(
-        new NodeType('paragraph', mockSchema, spec),
-        {},
-        content,
-        []
-      );
+      const node = new Node(paragraphType, {}, content, []);
 
       const result = node.cut(0, 2);
 
@@ -153,15 +158,10 @@ describe('Node', () => {
 
   describe('child', () => {
     it('given valid index, returns child node', () => {
-      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
       const content = Fragment.from([child1, child2]);
-      const node = new Node(
-        new NodeType('paragraph', mockSchema, spec),
-        {},
-        content,
-        []
-      );
+      const node = new Node(paragraphType, {}, content, []);
 
       expect(node.child(0)).toBe(child1);
     });
@@ -169,29 +169,19 @@ describe('Node', () => {
 
   describe('maybeChild', () => {
     it('given valid index, returns child node', () => {
-      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
       const content = Fragment.from([child1, child2]);
-      const node = new Node(
-        new NodeType('paragraph', mockSchema, spec),
-        {},
-        content,
-        []
-      );
+      const node = new Node(paragraphType, {}, content, []);
 
       expect(node.maybeChild(0)).toBe(child1);
     });
 
     it('given invalid index, returns null', () => {
-      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
       const content = Fragment.from([child1, child2]);
-      const node = new Node(
-        new NodeType('paragraph', mockSchema, spec),
-        {},
-        content,
-        []
-      );
+      const node = new Node(paragraphType, {}, content, []);
 
       expect(node.maybeChild(2)).toBeNull();
     });
@@ -199,15 +189,10 @@ describe('Node', () => {
 
   describe('firstChild', () => {
     it('given non-empty content, returns first child', () => {
-      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
       const content = Fragment.from([child1, child2]);
-      const node = new Node(
-        new NodeType('paragraph', mockSchema, spec),
-        {},
-        content,
-        []
-      );
+      const node = new Node(paragraphType, {}, content, []);
 
       expect(node.firstChild).toBe(child1);
     });
@@ -215,15 +200,10 @@ describe('Node', () => {
 
   describe('lastChild', () => {
     it('given non-empty content, returns last child', () => {
-      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
       const content = Fragment.from([child1, child2]);
-      const node = new Node(
-        new NodeType('paragraph', mockSchema, spec),
-        {},
-        content,
-        []
-      );
+      const node = new Node(paragraphType, {}, content, []);
 
       expect(node.lastChild).toBe(child2);
     });
@@ -232,7 +212,7 @@ describe('Node', () => {
   describe('mark', () => {
     it('given same maerks reference, returns same reference', () => {
       const marks = [createMark(boldMarkType, { color: 'purple' })];
-      const node = new Node(type, {}, mockContent, marks);
+      const node = new Node(paragraphType, {}, mockContent, marks);
 
       const newNode = node.mark(marks);
 
@@ -241,7 +221,7 @@ describe('Node', () => {
 
     it('given different marks, returns new node updating marks', () => {
       const marks = [createMark(boldMarkType, { color: 'purple' })];
-      const node = new Node(type, {}, mockContent, marks);
+      const node = new Node(paragraphType, {}, mockContent, marks);
 
       const newMarks = [createMark(italicMarkType, { color: 'red' })];
       const newNode = node.mark(newMarks);
@@ -253,32 +233,25 @@ describe('Node', () => {
   describe('hasMarkup', () => {
     it('given matching type/attrs/marks, returns true', () => {
       const marks = [createMark(boldMarkType, { color: 'purple' })];
-      const node = new Node(type, { level: 1 }, mockContent, marks);
+      const node = new Node(paragraphType, { level: 1 }, mockContent, marks);
 
-      expect(node.hasMarkup(type, { level: 1 }, marks)).toBe(true);
+      expect(node.hasMarkup(paragraphType, { level: 1 }, marks)).toBe(true);
     });
 
     it('given non-matching type, returns false', () => {
       const marks = [createMark(boldMarkType, { color: 'purple' })];
-      const node = new Node(type, { level: 1 }, mockContent, marks);
+      const node = new Node(paragraphType, { level: 1 }, mockContent, marks);
 
-      const otherType = new NodeType('heading', mockSchema, spec);
-
-      expect(node.hasMarkup(otherType, { level: 1 }, marks)).toBe(false);
+      expect(node.hasMarkup(headingType, { level: 1 }, marks)).toBe(false);
     });
   });
 
   describe('forEach', () => {
     it('given non-empty content, calls callback with each child node/offset/index', () => {
-      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
       const content = Fragment.from([child1, child2]);
-      const node = new Node(
-        new NodeType('paragraph', mockSchema, spec),
-        {},
-        content,
-        []
-      );
+      const node = new Node(paragraphType, {}, content, []);
 
       const callback = jest.fn();
 
@@ -291,7 +264,11 @@ describe('Node', () => {
 
   describe('contentMatchAt', () => {
     it('given valid index, returns ContentMatch for content at index', () => {
-      const nodeType = new NodeType('paragraph', mockSchema, spec);
+      const nodeType = new NodeType(
+        'paragraph',
+        defaultMockSchema,
+        defaultNodeSpec
+      );
       nodeType.contentMatch = ContentMatch.parse('paragraph', {
         paragraph: nodeType,
       });
@@ -307,14 +284,9 @@ describe('Node', () => {
     });
 
     it('given index that fails to find content match, throws error', () => {
-      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child1 = new Node(paragraphType, {});
       const content = Fragment.from([child1]);
-      const node = new Node(
-        new NodeType('paragraph', mockSchema, spec),
-        {},
-        content,
-        []
-      );
+      const node = new Node(paragraphType, {}, content, []);
 
       expect(() => node.contentMatchAt(1)).toThrow(
         'Called contentMatchAt on a node with invalid content'
@@ -324,15 +296,10 @@ describe('Node', () => {
 
   describe('resolveNoCache', () => {
     it('given valid pos, returns ResolvedPos', () => {
-      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
       const content = Fragment.from([child1, child2]);
-      const node = new Node(
-        new NodeType('paragraph', mockSchema, spec),
-        {},
-        content,
-        []
-      );
+      const node = new Node(paragraphType, {}, content, []);
 
       const resolvedPos = node.resolveNoCache(1);
 
@@ -342,28 +309,18 @@ describe('Node', () => {
 
   describe('nodeAt', () => {
     it('given pos beyond content, returns null', () => {
-      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child1 = new Node(paragraphType, {});
       const content = Fragment.from([child1]);
-      const node = new Node(
-        new NodeType('paragraph', mockSchema, spec),
-        {},
-        content,
-        []
-      );
+      const node = new Node(paragraphType, {}, content, []);
 
       expect(node.nodeAt(node.content.size)).toBeNull();
     });
 
     it('given valid pos, returns node at position', () => {
-      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
       const content = Fragment.from([child1, child2]);
-      const node = new Node(
-        new NodeType('paragraph', mockSchema, spec),
-        {},
-        content,
-        []
-      );
+      const node = new Node(paragraphType, {}, content, []);
 
       expect(node.nodeAt(2)).toBe(child2);
     });
@@ -371,13 +328,8 @@ describe('Node', () => {
 
   describe('childAfter', () => {
     it('given pos 0, returns first child with index 0 and offset 0', () => {
-      const child = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const node = new Node(
-        new NodeType('paragraph', mockSchema, spec),
-        {},
-        Fragment.from([child]),
-        []
-      );
+      const child = new Node(paragraphType, {});
+      const node = new Node(paragraphType, {}, Fragment.from([child]), []);
 
       const result = node.childAfter(0);
 
@@ -385,13 +337,8 @@ describe('Node', () => {
     });
 
     it('given pos at end of content, returns null node with index of last child and offset of last child end', () => {
-      const child = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const node = new Node(
-        new NodeType('paragraph', mockSchema, spec),
-        {},
-        Fragment.from([child]),
-        []
-      );
+      const child = new Node(paragraphType, {});
+      const node = new Node(paragraphType, {}, Fragment.from([child]), []);
 
       const result = node.childAfter(node.content.size);
 
@@ -401,13 +348,8 @@ describe('Node', () => {
 
   describe('childBefore', () => {
     it('given pos 0, returns null node with index 0 and offset 0', () => {
-      const child = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const node = new Node(
-        new NodeType('paragraph', mockSchema, spec),
-        {},
-        Fragment.from([child]),
-        []
-      );
+      const child = new Node(paragraphType, {});
+      const node = new Node(paragraphType, {}, Fragment.from([child]), []);
 
       const result = node.childBefore(0);
 
@@ -415,10 +357,10 @@ describe('Node', () => {
     });
 
     it('given pos at boundary, returns previous child with index of previous child and offset of previous child start', () => {
-      const child1 = new Node(new NodeType('paragraph', mockSchema, spec), {});
-      const child2 = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
       const node = new Node(
-        new NodeType('paragraph', mockSchema, spec),
+        paragraphType,
         {},
         Fragment.from([child1, child2]),
         []
@@ -432,58 +374,43 @@ describe('Node', () => {
 
   describe('type delegates getter', () => {
     it('given block node, isBlock returns true', () => {
-      const blockType = new NodeType('paragraph', mockSchema, spec);
-      const node = new Node(blockType, {}, mockContent, []);
+      const node = new Node(paragraphType, {}, mockContent, []);
 
       expect(node.isBlock).toBe(true);
     });
 
     it('given inline node, isInline returns true', () => {
-      const node = new Node(
-        new NodeType('span', mockSchema, { inline: true }),
-        {},
-        mockContent,
-        []
-      );
+      const node = new Node(spanType, {}, mockContent, []);
 
       expect(node.isInline).toBe(true);
     });
 
     it('given text node, isText returns true', () => {
-      const node = new Node(
-        new NodeType('text', mockSchema, { inline: true, text: true }),
-        {},
-        mockContent,
-        []
-      );
+      const node = new Node(textType, {}, mockContent, []);
 
       expect(node.isText).toBe(true);
     });
 
     it('given leaf node, isLeaf returns true', () => {
-      const node = new Node(
-        new NodeType('image', mockSchema, { leaf: true }),
-        {},
-        mockContent,
-        []
+      const nodeType = createMockNodeType(
+        'image',
+        defaultMockSchema,
+        createNodeSpec()
       );
+      nodeType.contentMatch = ContentMatch.empty;
+      const node = new Node(nodeType, {}, mockContent, []);
 
       expect(node.isLeaf).toBe(true);
     });
 
     it('given atom node, isAtom returns true', () => {
-      const node = new Node(
-        new NodeType('mention', mockSchema, { atom: true }),
-        {},
-        mockContent,
-        []
-      );
+      const node = new Node(mentionType, {}, mockContent, []);
 
       expect(node.isAtom).toBe(true);
     });
 
     it('given textblock node, isTextblock returns true', () => {
-      const nodeType = new NodeType('p', mockSchema, spec);
+      const nodeType = new NodeType('p', defaultMockSchema, defaultNodeSpec);
       nodeType.inlineContent = true;
       const node = new Node(nodeType, {}, mockContent, []);
 
@@ -491,7 +418,7 @@ describe('Node', () => {
     });
 
     it('given node with inlineContent set, inlineContent returns value', () => {
-      const nodeType = new NodeType('p', mockSchema, spec);
+      const nodeType = new NodeType('p', defaultMockSchema, defaultNodeSpec);
       nodeType.inlineContent = true;
       const node = new Node(nodeType, {}, mockContent, []);
 
@@ -502,7 +429,7 @@ describe('Node', () => {
   describe('toString', () => {
     // Node.spec.ts
     it('given a node, returns string representation', () => {
-      const node = new Node(new NodeType('paragraph', mockSchema, spec), {});
+      const node = new Node(paragraphType, {});
 
       expect(node.toString()).toBe('paragraph');
     });

--- a/packages/core/document/src/lib/entities/TextNode.spec.ts
+++ b/packages/core/document/src/lib/entities/TextNode.spec.ts
@@ -1,44 +1,37 @@
-import { MarkSpec } from '../interfaces/SchemaSpec';
-import { Mark } from '../value-objects/Mark';
-import { MarkType } from '../value-objects/MarkType';
-import { NodeType } from '../value-objects/NodeType';
 import { TextNode } from './TextNode';
-
-const createMark = (type: MarkType, attrs: Record<string, unknown>) =>
-  new Mark(type, attrs);
-
-const mockSchema = {} as never;
-const spec: MarkSpec = { attrs: {} };
+import {
+  textType,
+  boldMarkType,
+  italicMarkType,
+  createMark,
+} from '../../testing';
 
 describe('TextNode', () => {
   describe('constructor', () => {
     it('given valid type, text and marks, creates a TextNode instance', () => {
-      const nodeType = new NodeType('text', mockSchema, { attrs: {} });
       const attrs = { color: 'red' };
       const text = 'hello world';
-      const marks = [createMark(new MarkType('bold', mockSchema, spec), {})];
+      const marks = [createMark(boldMarkType, {})];
 
-      const textNode = new TextNode(nodeType, attrs, text, marks);
+      const textNode = new TextNode(textType, attrs, text, marks);
 
       expect(textNode).toBeInstanceOf(TextNode);
     });
 
     it('given empty text, throws RangeError', () => {
-      const nodeType = new NodeType('text', mockSchema, { attrs: {} });
       const attrs = { color: 'red' };
       const text = '';
 
-      expect(() => new TextNode(nodeType, attrs, text)).toThrow(
+      expect(() => new TextNode(textType, attrs, text)).toThrow(
         'Node text cannot be empty'
       );
     });
 
     it('given null text, throws RangeError', () => {
-      const nodeType = new NodeType('text', mockSchema, { attrs: {} });
       const attrs = { color: 'red' };
       const text = null as never;
 
-      expect(() => new TextNode(nodeType, attrs, text)).toThrow(
+      expect(() => new TextNode(textType, attrs, text)).toThrow(
         'Node text cannot be empty'
       );
     });
@@ -46,11 +39,10 @@ describe('TextNode', () => {
 
   describe('nodeSize', () => {
     it('given text, returns length of text', () => {
-      const nodeType = new NodeType('text', mockSchema, { attrs: {} });
       const attrs = { color: 'red' };
       const text = 'hello world';
 
-      const textNode = new TextNode(nodeType, attrs, text);
+      const textNode = new TextNode(textType, attrs, text);
 
       expect(textNode.nodeSize).toBe(11);
     });
@@ -58,11 +50,10 @@ describe('TextNode', () => {
 
   describe('textBetween', () => {
     it('given range, returns sliced text', () => {
-      const nodeType = new NodeType('text', mockSchema, { attrs: {} });
       const attrs = { color: 'red' };
       const text = 'hello world';
 
-      const textNode = new TextNode(nodeType, attrs, text);
+      const textNode = new TextNode(textType, attrs, text);
 
       expect(textNode.textBetween(0, 5)).toBe('hello');
     });
@@ -70,21 +61,19 @@ describe('TextNode', () => {
 
   describe('withText', () => {
     it('given same text, returns same reference', () => {
-      const nodeType = new NodeType('text', mockSchema, { attrs: {} });
       const attrs = { color: 'red' };
       const text = 'hello world';
 
-      const textNode = new TextNode(nodeType, attrs, text);
+      const textNode = new TextNode(textType, attrs, text);
       const result = textNode.withText(text);
 
       expect(result).toBe(textNode);
     });
 
     it('given different text, returns new TextNode with updated text', () => {
-      const nodeType = new NodeType('text', mockSchema, { attrs: {} });
       const attrs = { color: 'red' };
 
-      const textNode = new TextNode(nodeType, attrs, 'hello world');
+      const textNode = new TextNode(textType, attrs, 'hello world');
       const result = textNode.withText('Hola mundo');
 
       expect(result).not.toBe(textNode);
@@ -94,27 +83,23 @@ describe('TextNode', () => {
 
   describe('mark', () => {
     it('given same marks, returns same reference', () => {
-      const nodeType = new NodeType('text', mockSchema, { attrs: {} });
       const attrs = { color: 'red' };
       const text = 'hello world';
-      const marks = [createMark(new MarkType('bold', mockSchema, spec), {})];
+      const marks = [createMark(boldMarkType, {})];
 
-      const textNode = new TextNode(nodeType, attrs, text, marks);
+      const textNode = new TextNode(textType, attrs, text, marks);
       const result = textNode.mark(marks);
 
       expect(result).toBe(textNode);
     });
 
     it('given different marks, returns new TextNode with updated marks', () => {
-      const nodeType = new NodeType('text', mockSchema, { attrs: {} });
       const attrs = { color: 'red' };
       const text = 'hello world';
-      const marks = [createMark(new MarkType('bold', mockSchema, spec), {})];
-      const newMarks = [
-        createMark(new MarkType('italic', mockSchema, spec), {}),
-      ];
+      const marks = [createMark(boldMarkType, {})];
+      const newMarks = [createMark(italicMarkType, {})];
 
-      const textNode = new TextNode(nodeType, attrs, text, marks);
+      const textNode = new TextNode(textType, attrs, text, marks);
       const result = textNode.mark(newMarks);
 
       expect(result).not.toBe(textNode);
@@ -124,22 +109,20 @@ describe('TextNode', () => {
 
   describe('cut', () => {
     it('given full range, returns same reference', () => {
-      const nodeType = new NodeType('text', mockSchema, { attrs: {} });
       const attrs = { color: 'red' };
       const text = 'hello world';
 
-      const textNode = new TextNode(nodeType, attrs, text);
+      const textNode = new TextNode(textType, attrs, text);
       const result = textNode.cut(0, text.length);
 
       expect(result).toBe(textNode);
     });
 
     it('given partial range, returns new TextNode with sliced text', () => {
-      const nodeType = new NodeType('text', mockSchema, { attrs: {} });
       const attrs = { color: 'red' };
       const text = 'hello world';
 
-      const textNode = new TextNode(nodeType, attrs, text);
+      const textNode = new TextNode(textType, attrs, text);
       const result = textNode.cut(0, 5);
 
       expect(result).not.toBe(textNode);
@@ -149,12 +132,11 @@ describe('TextNode', () => {
 
   describe('equals', () => {
     it('given different text, returns false', () => {
-      const nodeType = new NodeType('text', mockSchema, { attrs: {} });
       const attrs = { color: 'red' };
-      const marks = [createMark(new MarkType('bold', mockSchema, spec), {})];
+      const marks = [createMark(boldMarkType, {})];
 
-      const textNode1 = new TextNode(nodeType, attrs, 'hello world', marks);
-      const textNode2 = new TextNode(nodeType, attrs, 'Hola mundo', marks);
+      const textNode1 = new TextNode(textType, attrs, 'hello world', marks);
+      const textNode2 = new TextNode(textType, attrs, 'Hola mundo', marks);
 
       expect(textNode1.equals(textNode2)).toBe(false);
     });
@@ -163,8 +145,7 @@ describe('TextNode', () => {
   describe('toString', () => {
     // TextNode.spec.ts
     it('given a text node, returns string representation', () => {
-      const nodeType = new NodeType('text', mockSchema, { attrs: {} });
-      const textNode = new TextNode(nodeType, {}, 'hello');
+      const textNode = new TextNode(textType, {}, 'hello');
 
       expect(textNode.toString()).toBe('"hello"');
     });

--- a/packages/core/document/src/lib/interfaces/SchemaSpec.ts
+++ b/packages/core/document/src/lib/interfaces/SchemaSpec.ts
@@ -6,13 +6,13 @@ export interface SchemaSpec {
 
 export interface NodeSpec {
   atom?: boolean;
-  content?: string;
   attrs?: Record<string, AttributeSpec>;
-  inline?: boolean;
+  code?: boolean;
+  content?: string;
   group?: string;
+  inline?: boolean;
   marks?: string;
-  leaf?: boolean;
-  text?: boolean;
+  whitespace?: 'normal' | 'pre';
 }
 
 export interface MarkSpec {

--- a/packages/core/document/src/lib/services/Schema.spec.ts
+++ b/packages/core/document/src/lib/services/Schema.spec.ts
@@ -1,33 +1,18 @@
 import { Node } from '../entities/Node';
-import { MarkSpec, NodeSpec } from '../interfaces/SchemaSpec';
 import { ContentMatch } from '../value-objects/ContentMatch';
 import { Mark } from '../value-objects/Mark';
 import { MarkType } from '../value-objects/MarkType';
 import { NodeType } from '../value-objects/NodeType';
 import { Schema } from './Schema';
-
-function createNodeSpec(extra?: Record<string, NodeSpec>): Record<string, NodeSpec> {
-  return {
-    doc: { content: 'paragraph+' },
-    text: { text: true },
-    paragraph: { attrs: {} },
-    heading: { attrs: {} },
-    ...extra,
-  };
-}
-
-function createMarkSpec(extra?: Record<string, MarkSpec>): Record<string, MarkSpec> {
-  return {
-    strong: { attrs: {} },
-    em: { attrs: {} },
-    ...extra,
-  };
-}
+import { createSchemaSpec, createMarkSpec } from '../../testing';
 
 describe('Schema', () => {
   describe('constructor', () => {
     it('given valid nodes and marks specs, creates Schema instance', () => {
-      const schema = new Schema({ nodes: createNodeSpec(), marks: createMarkSpec() });
+      const schema = new Schema({
+        nodes: createSchemaSpec(),
+        marks: createMarkSpec(),
+      });
 
       expect(schema).toBeInstanceOf(Schema);
     });
@@ -46,7 +31,7 @@ describe('Schema', () => {
 
     it('given null marks spec, throws "Schema marks spec cannot be null"', () => {
       expect(
-        () => new Schema({ nodes: createNodeSpec(), marks: null as never })
+        () => new Schema({ nodes: createSchemaSpec(), marks: null as never })
       ).toThrow('Schema marks spec cannot be null');
     });
 
@@ -63,7 +48,7 @@ describe('Schema', () => {
       expect(
         () =>
           new Schema({
-            nodes: { text: { text: true }, paragraph: {} },
+            nodes: { text: {  }, paragraph: {} },
           })
       ).toThrow("Every schema needs a 'doc' type");
     });
@@ -74,7 +59,7 @@ describe('Schema', () => {
           new Schema({
             nodes: {
               doc: { content: 'paragraph+' },
-              text: { text: true },
+              text: { },
               strong: {},
             },
             marks: { strong: {} },
@@ -83,14 +68,17 @@ describe('Schema', () => {
     });
 
     it('given node with content expression, sets contentMatch', () => {
-      const schema = new Schema({ nodes: createNodeSpec(), marks: createMarkSpec() });
+      const schema = new Schema({
+        nodes: createSchemaSpec(),
+        marks: createMarkSpec(),
+      });
 
       expect(schema.nodes.doc.contentMatch).toBeInstanceOf(ContentMatch);
     });
 
     it('given inline node, inlineContent is true', () => {
       const schema = new Schema({
-        nodes: createNodeSpec({ span: { inline: true, content: 'text*' } }),
+        nodes: createSchemaSpec({ span: { inline: true, content: 'text*' } }),
         marks: createMarkSpec(),
       });
 
@@ -99,7 +87,7 @@ describe('Schema', () => {
 
     it(`given node with marks "", markSet is empty array`, () => {
       const schema = new Schema({
-        nodes: createNodeSpec({ span: { content: 'text*', marks: '' } }),
+        nodes: createSchemaSpec({ span: { content: 'text*', marks: '' } }),
         marks: createMarkSpec(),
       });
 
@@ -108,7 +96,7 @@ describe('Schema', () => {
 
     it('given marks in order, rank reflects insertion order', () => {
       const schema = new Schema({
-        nodes: createNodeSpec(),
+        nodes: createSchemaSpec(),
         marks: {
           em: { attrs: {} },
           strong: { attrs: {} },
@@ -120,7 +108,7 @@ describe('Schema', () => {
 
     it('given marks with no excludes spec, excluded contains self', () => {
       const schema = new Schema({
-        nodes: createNodeSpec(),
+        nodes: createSchemaSpec(),
         marks: {
           em: { attrs: {} },
           strong: { attrs: {} },
@@ -132,22 +120,28 @@ describe('Schema', () => {
 
     it(`given marks with excludes "", excludes is empty array`, () => {
       const schema = new Schema({
-        nodes: createNodeSpec(),
-        marks: createMarkSpec({ em: { attrs: {}, excludes: '' }, strong: { attrs: {}, excludes: '' } }),
+        nodes: createSchemaSpec(),
+        marks: createMarkSpec({
+          em: { attrs: {}, excludes: '' },
+          strong: { attrs: {}, excludes: '' },
+        }),
       });
 
       expect(schema.marks.em.excluded).toEqual([]);
     });
 
     it('given no topNode in spec, topNodeType is doc NodeType', () => {
-      const schema = new Schema({ nodes: createNodeSpec(), marks: createMarkSpec() });
+      const schema = new Schema({
+        nodes: createSchemaSpec(),
+        marks: createMarkSpec(),
+      });
 
       expect(schema.topNodeType).toBe(schema.nodes.doc);
     });
 
     it('given topNode in spec, topNodeType is that NodeType', () => {
       const schema = new Schema({
-        nodes: createNodeSpec(),
+        nodes: createSchemaSpec(),
         marks: createMarkSpec(),
         topNode: 'paragraph',
       });
@@ -158,7 +152,10 @@ describe('Schema', () => {
 
   describe('text()', () => {
     it('given a string to text(), returns TextNode', () => {
-      const schema = new Schema({ nodes: createNodeSpec(), marks: createMarkSpec() });
+      const schema = new Schema({
+        nodes: createSchemaSpec(),
+        marks: createMarkSpec(),
+      });
       const textNode = schema.text('hello');
 
       expect(textNode).toBeInstanceOf(Node);
@@ -167,14 +164,20 @@ describe('Schema', () => {
 
   describe('node()', () => {
     it('given a string type to node(), returns Node of that type', () => {
-      const schema = new Schema({ nodes: createNodeSpec(), marks: createMarkSpec() });
+      const schema = new Schema({
+        nodes: createSchemaSpec(),
+        marks: createMarkSpec(),
+      });
       const headingNode = schema.node('heading');
 
       expect(headingNode.type).toBe(schema.nodes.heading);
     });
 
     it('given unknown string type to node(), throws', () => {
-      const schema = new Schema({ nodes: createNodeSpec(), marks: createMarkSpec() });
+      const schema = new Schema({
+        nodes: createSchemaSpec(),
+        marks: createMarkSpec(),
+      });
 
       expect(() => schema.node('unknown')).toThrow(
         'Unknown node type: "unknown"'
@@ -184,14 +187,20 @@ describe('Schema', () => {
 
   describe('mark()', () => {
     it('given a string type to mark(), returns Mark', () => {
-      const schema = new Schema({ nodes: createNodeSpec(), marks: createMarkSpec() });
+      const schema = new Schema({
+        nodes: createSchemaSpec(),
+        marks: createMarkSpec(),
+      });
       const strongMark = schema.mark('strong');
 
       expect(strongMark).toBeInstanceOf(Mark);
     });
 
     it('given unknown string type to mark(), throws', () => {
-      const schema = new Schema({ nodes: createNodeSpec(), marks: createMarkSpec() });
+      const schema = new Schema({
+        nodes: createSchemaSpec(),
+        marks: createMarkSpec(),
+      });
 
       expect(() => schema.mark('unknown')).toThrow(
         'Unknown mark type: "unknown"'
@@ -201,7 +210,10 @@ describe('Schema', () => {
 
   describe('nodes property', () => {
     it('given valid nodes spec, contains NodeType instance for each spec', () => {
-      const schema = new Schema({ nodes: createNodeSpec(), marks: createMarkSpec() });
+      const schema = new Schema({
+        nodes: createSchemaSpec(),
+        marks: createMarkSpec(),
+      });
 
       expect(schema.nodes.paragraph).toBeInstanceOf(NodeType);
       expect(schema.nodes.heading).toBeInstanceOf(NodeType);
@@ -213,7 +225,10 @@ describe('Schema', () => {
 
   describe('marks property', () => {
     test('given valid marks spec, contains MarkType instance for each spec', () => {
-      const schema = new Schema({ nodes: createNodeSpec(), marks: createMarkSpec() });
+      const schema = new Schema({
+        nodes: createSchemaSpec(),
+        marks: createMarkSpec(),
+      });
 
       expect(schema.marks.strong).toBeInstanceOf(MarkType);
       expect(schema.marks.em).toBeInstanceOf(MarkType);

--- a/packages/core/document/src/lib/value-objects/ContentMatch.spec.ts
+++ b/packages/core/document/src/lib/value-objects/ContentMatch.spec.ts
@@ -1,38 +1,12 @@
 import { ContentMatch } from './ContentMatch';
-import { NodeType } from './NodeType';
-import { Node } from '../entities/Node';
 import { Fragment } from '../entities/Fragment';
-import { Edge } from '../interfaces/Edge';
-
-// Test Helpers
-function createMockNodeType(
-  name = 'paragraph',
-  options: { inline?: boolean } = {}
-): NodeType {
-  return new NodeType(
-    name,
-    {},
-    { attrs: { content: { default: 'text*' } }, inline: options.inline }
-  );
-}
-
-function createMockContentMatch(
-  validEnd = true,
-  edges: Edge[] = []
-): ContentMatch {
-  return new ContentMatch(validEnd, edges);
-}
-
-function createMockNode(type?: NodeType): Node<Record<string, unknown>> {
-  const nodeType = type || createMockNodeType();
-  return new Node(nodeType, {});
-}
-
-function createMockFragment(
-  nodes: Node<Record<string, unknown>>[] = []
-): Fragment<Node<Record<string, unknown>>> {
-  return nodes.length === 0 ? Fragment.empty() : Fragment.from(nodes);
-}
+import {
+  createMockNodeType,
+  createMockContentMatch,
+  createMockNode,
+  createMockFragment,
+  textType,
+} from '../../testing';
 
 describe('ContentMatch', () => {
   describe('constructor and validation', () => {
@@ -423,11 +397,10 @@ describe('ContentMatch', () => {
     });
 
     it('skips text type and returns first non-text type', () => {
-      const realTextType = new NodeType('text', {}, { attrs: {}, text: true });
       const paragraphType = createMockNodeType('paragraph');
       const nextMatch = new ContentMatch(true, []);
       const edges = [
-        { type: realTextType, next: nextMatch },
+        { type: textType, next: nextMatch },
         { type: paragraphType, next: nextMatch },
       ];
       const match = new ContentMatch(false, edges);
@@ -461,7 +434,7 @@ describe('ContentMatch', () => {
   describe('fillBefore(after, toEnd, startIndex)', () => {
     it('given matching fragment, returns empty fragment', () => {
       const paragraphType = createMockNodeType('paragraph');
-      const mockFragment = createMockFragment([new Node(paragraphType, {})]);
+      const mockFragment = createMockFragment([createMockNode(paragraphType)]);
       const nextMatch = new ContentMatch(true, []);
       const match = createMockContentMatch(false, [
         { type: paragraphType, next: nextMatch },
@@ -486,7 +459,7 @@ describe('ContentMatch', () => {
       ]);
 
       const result = match1.fillBefore(
-        Fragment.from([new Node(paragraphType, {})]),
+        createMockFragment([createMockNode(paragraphType)]),
         false
       );
 
@@ -503,7 +476,7 @@ describe('ContentMatch', () => {
         { type: headingType, next: finalMatch },
       ]);
 
-      const result = match.fillBefore(Fragment.empty(), true);
+      const result = match.fillBefore(createMockFragment(), true);
 
       expect(result).toBeInstanceOf(Fragment);
       expect(result?.childCount).toBe(1);
@@ -517,7 +490,7 @@ describe('ContentMatch', () => {
         { type: headingType, next: deadEnd },
       ]);
 
-      const result = match.fillBefore(Fragment.empty(), true);
+      const result = match.fillBefore(createMockFragment(), true);
 
       expect(result).toBeNull();
     });
@@ -542,7 +515,7 @@ describe('ContentMatch', () => {
         { type: headingType, next: match2 },
       ]);
 
-      const result = match1.fillBefore(Fragment.empty(), true);
+      const result = match1.fillBefore(createMockFragment(), true);
 
       expect(result).toBeInstanceOf(Fragment);
       expect(result?.childCount).toBe(2);
@@ -560,8 +533,8 @@ describe('ContentMatch', () => {
       ]);
 
       const fragment = createMockFragment([
-        new Node(headingType, {}),
-        new Node(paragraphType, {}),
+        createMockNode(headingType),
+        createMockNode(paragraphType),
       ]);
 
       const result = start.fillBefore(fragment, false, 1);
@@ -582,7 +555,7 @@ describe('ContentMatch', () => {
         { type: paragraphType, next: validEnd },
       ]);
 
-      const result = start.fillBefore(Fragment.empty(), true);
+      const result = start.fillBefore(createMockFragment(), true);
 
       expect(result).toBeInstanceOf(Fragment);
       expect(result?.childCount).toBe(1);

--- a/packages/core/document/src/lib/value-objects/Mark.spec.ts
+++ b/packages/core/document/src/lib/value-objects/Mark.spec.ts
@@ -1,14 +1,10 @@
-import { MarkSpec } from '../interfaces/SchemaSpec';
 import { Mark } from './Mark';
-import { MarkType } from './MarkType';
-
-const createMarkType = (name: string, schema: unknown, spec: MarkSpec) =>
-  new MarkType(name, schema, spec);
-const boldMarkType = createMarkType('bold', {}, {});
-const italicMarkType = createMarkType('italic', {}, {});
-
-const createMark = (type: MarkType, attrs: Record<string, unknown>) =>
-  new Mark(type, attrs);
+import {
+  createMarkType,
+  boldMarkType,
+  italicMarkType,
+  createMark,
+} from '../../testing';
 
 describe('Mark', () => {
   describe('constructor', () => {

--- a/packages/core/document/src/lib/value-objects/MarkSet.spec.ts
+++ b/packages/core/document/src/lib/value-objects/MarkSet.spec.ts
@@ -1,12 +1,6 @@
 import { Mark } from './Mark';
 import { MarkSet } from './MarkSet';
-import { MarkType } from './MarkType';
-
-const createMarkType = (name: string) => new MarkType(name, {}, {});
-
-function createMarks(...types: string[]): Mark[] {
-  return types.map((type) => new Mark(createMarkType(type), {}));
-}
+import { createMarkType, createMarks } from '../../testing';
 
 describe('MarkSet Value Object', () => {
   describe('Construction', () => {
@@ -47,7 +41,7 @@ describe('MarkSet Value Object', () => {
       const marks = createMarks('strong', 'italic');
 
       const markSet = MarkSet.from(marks);
-      marks.push(new Mark(createMarkType('pre'), {}));
+      marks.push(new Mark(createMarkType('pre', {}, {}), {}));
 
       expect(markSet.size).toBe(2);
     });
@@ -73,7 +67,7 @@ describe('MarkSet Value Object', () => {
     it('add, given empty markset, returns new markset with mark', () => {
       const markSet = MarkSet.empty();
 
-      const result = markSet.add(new Mark(createMarkType('bold'), {}));
+      const result = markSet.add(new Mark(createMarkType('bold', {}, {}), {}));
 
       expect(result).toBeInstanceOf(MarkSet);
     });
@@ -83,13 +77,15 @@ describe('MarkSet Value Object', () => {
 
       const markSet = MarkSet.from([mark1, mark2]);
 
-      const result = markSet.add(new Mark(createMarkType('underline'), {}));
+      const result = markSet.add(
+        new Mark(createMarkType('underline', {}, {}), {})
+      );
 
       expect(result).toBeInstanceOf(MarkSet);
     });
 
     it('add, given mark with same type exists, returns same instance', () => {
-      const strongMarkType = createMarkType('strong');
+      const strongMarkType = createMarkType('strong', {}, {});
       const mark1 = new Mark(strongMarkType, { color: 'red' });
       const mark2 = new Mark(strongMarkType, { color: 'blue' });
 
@@ -105,7 +101,7 @@ describe('MarkSet Value Object', () => {
 
       const markSet = MarkSet.from([mark1, mark2]);
 
-      markSet.add(new Mark(createMarkType('underline'), {}));
+      markSet.add(new Mark(createMarkType('underline', {}, {}), {}));
 
       expect(markSet.size).toBe(2);
     });
@@ -123,21 +119,25 @@ describe('MarkSet Value Object', () => {
       const [markStrong, markItalic] = createMarks('strong', 'italic');
       const markSet = MarkSet.from([markStrong, markItalic]);
 
-      expect(markSet.contains(new Mark(createMarkType('underline'), {}))).toBe(false);
+      expect(
+        markSet.contains(new Mark(createMarkType('underline', {}, {}), {}))
+      ).toBe(false);
     });
 
     it('contains, given empty markset, returns false', () => {
       const markSet = MarkSet.empty();
 
-      expect(markSet.contains(new Mark(createMarkType('strong'), { color: 'red' }))).toBe(
-        false
-      );
+      expect(
+        markSet.contains(
+          new Mark(createMarkType('strong', {}, {}), { color: 'red' })
+        )
+      ).toBe(false);
     });
   });
 
   describe('remove() method', () => {
     it('remove, given mark exists, returns new markset without mark', () => {
-      const mark = new Mark(createMarkType('strong'), { color: 'red' });
+      const mark = new Mark(createMarkType('strong', {}, {}), { color: 'red' });
       const markSet = MarkSet.from([mark]);
 
       const result = markSet.remove(mark);
@@ -148,7 +148,7 @@ describe('MarkSet Value Object', () => {
 
     it('remove, given mark does not exist, returns same instance', () => {
       const [markStrong, markItalic] = createMarks('strong', 'italic');
-      const markUnderline = new Mark(createMarkType('underline'), {});
+      const markUnderline = new Mark(createMarkType('underline', {}, {}), {});
 
       const markSet = MarkSet.from([markStrong, markItalic]);
 
@@ -158,7 +158,7 @@ describe('MarkSet Value Object', () => {
     });
 
     it('remove, given empty markset, returns same instance', () => {
-      const mark = new Mark(createMarkType('strong'), { color: 'red' });
+      const mark = new Mark(createMarkType('strong', {}, {}), { color: 'red' });
       const markSet = MarkSet.empty();
 
       const result = markSet.remove(mark);

--- a/packages/core/document/src/lib/value-objects/MarkType.spec.ts
+++ b/packages/core/document/src/lib/value-objects/MarkType.spec.ts
@@ -1,71 +1,81 @@
-import { MarkSpec } from '../interfaces/SchemaSpec';
 import { Mark } from './Mark';
 import { MarkType } from './MarkType';
-
-const mockSchema = {} as never;
-const spec: MarkSpec = { attrs: {} };
+import {
+  defaultMockSchema,
+  defaultMarkSpec,
+  boldMarkType,
+  italicMarkType,
+  createMarkType,
+} from '../../testing';
 
 describe('MarkType', () => {
   describe('constructor', () => {
     it('given valid parameters, returns instance of MarkType', () => {
-      const markType = new MarkType('paragraph', mockSchema, spec);
-      expect(markType).toBeInstanceOf(MarkType);
-      expect(markType.name).toBe('paragraph');
+      expect(
+        createMarkType('paragraph', defaultMockSchema, defaultMarkSpec)
+      ).toBeInstanceOf(MarkType);
+      expect(
+        createMarkType('paragraph', defaultMockSchema, defaultMarkSpec).name
+      ).toBe('paragraph');
     });
 
     it('given empty name string, throws "MarkType name cannot be empty"', () => {
-      expect(() => new MarkType('', mockSchema, spec)).toThrow(
-        'MarkType name cannot be empty'
-      );
+      expect(() =>
+        createMarkType('', defaultMockSchema, defaultMarkSpec)
+      ).toThrow('MarkType name cannot be empty');
     });
 
     it('given whitespace-only name, throws "MarkType name cannot be empty"', () => {
-      expect(() => new MarkType('  ', mockSchema, spec)).toThrow(
-        'MarkType name cannot be empty'
-      );
+      expect(() =>
+        createMarkType('  ', defaultMockSchema, defaultMarkSpec)
+      ).toThrow('MarkType name cannot be empty');
     });
 
     it('given null name, throws "MarkType name cannot be empty"', () => {
-      expect(() => new MarkType(null as never, mockSchema, spec)).toThrow(
-        'MarkType name cannot be empty'
-      );
+      expect(() =>
+        createMarkType(null as never, defaultMockSchema, defaultMarkSpec)
+      ).toThrow('MarkType name cannot be empty');
     });
 
     it('given undefined name, throws "MarkType name cannot be empty"', () => {
-      expect(() => new MarkType(undefined as never, mockSchema, spec)).toThrow(
-        'MarkType name cannot be empty'
-      );
+      expect(() =>
+        createMarkType(undefined as never, defaultMockSchema, defaultMarkSpec)
+      ).toThrow('MarkType name cannot be empty');
     });
 
     it('given null schema, throws "MarkType schema cannot be null"', () => {
-      expect(() => new MarkType('paragraph', null as never, spec)).toThrow(
-        'MarkType schema cannot be null'
-      );
+      expect(() =>
+        createMarkType('paragraph', null as never, defaultMarkSpec)
+      ).toThrow('MarkType schema cannot be null');
     });
 
     it('given undefined schema, throws "MarkType schema cannot be undefined"', () => {
-      expect(() => new MarkType('paragraph', undefined as never, spec)).toThrow(
-        'MarkType schema cannot be undefined'
-      );
+      expect(() =>
+        createMarkType('paragraph', undefined as never, defaultMarkSpec)
+      ).toThrow('MarkType schema cannot be undefined');
     });
 
     it('given null spec, throws "MarkType spec cannot be null"', () => {
-      expect(
-        () => new MarkType('paragraph', mockSchema, null as never)
+      expect(() =>
+        createMarkType('paragraph', defaultMockSchema, null as never)
       ).toThrow('MarkType spec cannot be null');
     });
 
     it('given undefined spec, throws "MarkType spec cannot be undefined"', () => {
-      expect(
-        () => new MarkType('paragraph', mockSchema, undefined as never)
+      expect(() =>
+        createMarkType('paragraph', defaultMockSchema, undefined as never)
       ).toThrow('MarkType spec cannot be undefined');
     });
   });
 
   describe('equals', () => {
     it('given MarkTypes with same name, returns true', () => {
-      const markType1 = new MarkType('strong', mockSchema, spec);
-      const markType2 = new MarkType('strong', mockSchema, {
+      const markType1 = createMarkType(
+        'strong',
+        defaultMockSchema,
+        defaultMarkSpec
+      );
+      const markType2 = createMarkType('strong', defaultMockSchema, {
         attrs: { color: 'blue' },
       });
 
@@ -73,8 +83,12 @@ describe('MarkType', () => {
     });
 
     it('given MarkTypes with different names, returns false', () => {
-      const markType1 = new MarkType('strong', mockSchema, spec);
-      const markType2 = new MarkType('em', mockSchema, {
+      const markType1 = createMarkType(
+        'strong',
+        defaultMockSchema,
+        defaultMarkSpec
+      );
+      const markType2 = createMarkType('em', defaultMockSchema, {
         attrs: { color: 'blue' },
       });
 
@@ -82,7 +96,11 @@ describe('MarkType', () => {
     });
 
     it('given null parameter, throws "MarkType equals parameter cannot be null"', () => {
-      const markType1 = new MarkType('strong', mockSchema, spec);
+      const markType1 = createMarkType(
+        'strong',
+        defaultMockSchema,
+        defaultMarkSpec
+      );
 
       expect(() => markType1.equals(null as never)).toThrow(
         'MarkType equals parameter cannot be null'
@@ -92,14 +110,12 @@ describe('MarkType', () => {
 
   describe('create', () => {
     it('given no attrrs, creates Mark with empty attrs', () => {
-      const boldMarkType = new MarkType('bold', mockSchema, spec);
       const newMark = boldMarkType.create();
 
       expect(newMark).toEqual(new Mark(boldMarkType, {}));
     });
 
     it('given attrs, creates Mark with given attrs', () => {
-      const boldMarkType = new MarkType('bold', mockSchema, spec);
       const newMark = boldMarkType.create({ color: 'red' });
 
       expect(newMark).toEqual(new Mark(boldMarkType, { color: 'red' }));
@@ -108,7 +124,6 @@ describe('MarkType', () => {
 
   describe('isInSet', () => {
     it('given mark of this type in set, returns the mark', () => {
-      const boldMarkType = new MarkType('bold', mockSchema, spec);
       const mark1 = new Mark(boldMarkType, { color: 'red' });
       const mark2 = new Mark(boldMarkType, { color: 'blue' });
       const set = [mark1, mark2];
@@ -117,8 +132,6 @@ describe('MarkType', () => {
     });
 
     it('given no mark of this type in set, returns undefined', () => {
-      const boldMarkType = new MarkType('bold', mockSchema, spec);
-      const italicMarkType = new MarkType('italic', mockSchema, spec);
       const mark1 = new Mark(italicMarkType, { color: 'red' });
       const set = [mark1];
 
@@ -128,8 +141,6 @@ describe('MarkType', () => {
 
   describe('removeFromSet', () => {
     it('given mark of this type in set, returns new set without the mark', () => {
-      const boldMarkType = new MarkType('bold', mockSchema, spec);
-      const italicMarkType = new MarkType('italic', mockSchema, spec);
       const mark1 = new Mark(boldMarkType, { color: 'red' });
       const mark2 = new Mark(italicMarkType, { color: 'blue' });
       const set = [mark1, mark2];
@@ -138,8 +149,6 @@ describe('MarkType', () => {
     });
 
     it('given no mark of this type in set, returns returns same reference', () => {
-      const boldMarkType = new MarkType('bold', mockSchema, spec);
-      const italicMarkType = new MarkType('italic', mockSchema, spec);
       const mark1 = new Mark(italicMarkType, { color: 'red' });
       const set = [mark1];
 

--- a/packages/core/document/src/lib/value-objects/NodeRange.spec.ts
+++ b/packages/core/document/src/lib/value-objects/NodeRange.spec.ts
@@ -1,67 +1,62 @@
-import { Node } from '../entities/Node';
 import { NodeRange } from './NodeRange';
-import { NodeType } from './NodeType';
-import { ResolvedPos } from './ResolvedPos';
-
-const createMockNode = (name = 'paragraph'): Node =>
-  new Node(new NodeType(name, {} as never, { attrs: {} }), {});
+import { createMockNode, createResolvedPos } from '../../testing';
 
 describe('NodeRange', () => {
   describe('constructor', () => {
     it('given valid parameters, creates NodeRange instance', () => {
-      const $from = new ResolvedPos(1, [createMockNode(), 0, 0], 0);
-      const $to = new ResolvedPos(3, [createMockNode(), 0, 0], 0);
+      const $from = createResolvedPos(1);
+      const $to = createResolvedPos(3);
       const range = new NodeRange($from, $to, 0);
       expect(range).toBeInstanceOf(NodeRange);
     });
 
     it('given null $from, throws error', () => {
-      const $to = new ResolvedPos(3, [createMockNode(), 0, 0], 0);
+      const $to = createResolvedPos(3);
       expect(() => new NodeRange(null as never, $to, 0)).toThrow(
         'NodeRange $from cannot be null'
       );
     });
 
     it('given undefined $from, throws error', () => {
-      const $to = new ResolvedPos(3, [createMockNode(), 0, 0], 0);
+      const $to = createResolvedPos(3);
       expect(() => new NodeRange(undefined as never, $to, 0)).toThrow(
         'NodeRange $from cannot be undefined'
       );
     });
 
     it('given null $to, throws error', () => {
-      const $from = new ResolvedPos(1, [createMockNode(), 0, 0], 0);
+      const $from = createResolvedPos(1);
       expect(() => new NodeRange($from, null as never, 0)).toThrow(
         'NodeRange $to cannot be null'
       );
     });
 
     it('given undefined $to, throws error', () => {
-      const $from = new ResolvedPos(1, [createMockNode(), 0, 0], 0);
+      const $from = createResolvedPos(1);
       expect(() => new NodeRange($from, undefined as never, 0)).toThrow(
         'NodeRange $to cannot be undefined'
       );
     });
 
     it('given null depth, throws error', () => {
-      const $from = new ResolvedPos(1, [createMockNode(), 0, 0], 0);
-      const $to = new ResolvedPos(3, [createMockNode(), 0, 0], 0);
+      const $from = createResolvedPos(1);
+      const $to = createResolvedPos(3);
       expect(() => new NodeRange($from, $to, null as never)).toThrow(
         'NodeRange depth cannot be null'
       );
     });
 
     it('given undefined depth, throws error', () => {
-      const $from = new ResolvedPos(1, [createMockNode(), 0, 0], 0);
-      const $to = new ResolvedPos(3, [createMockNode(), 0, 0], 0);
+      const $from = createResolvedPos(1);
+      const $to = createResolvedPos(3);
       expect(() => new NodeRange($from, $to, undefined as never)).toThrow(
         'NodeRange depth cannot be undefined'
       );
     });
 
     it('given negative depth, throws error', () => {
-      const $from = new ResolvedPos(1, [createMockNode(), 0, 0], 0);
-      const $to = new ResolvedPos(3, [createMockNode(), 0, 0], 0);
+      const $from = createResolvedPos(1);
+      const $to = createResolvedPos(3);
       expect(() => new NodeRange($from, $to, -1)).toThrow(
         'NodeRange depth cannot be a negative number'
       );
@@ -70,8 +65,8 @@ describe('NodeRange', () => {
 
   describe('start', () => {
     it('given depth 0, returns position before the first child at depth 1', () => {
-      const $from = new ResolvedPos(1, [createMockNode(), 0, 1], 0);
-      const $to = new ResolvedPos(3, [createMockNode(), 0, 0], 0);
+      const $from = createResolvedPos(1, [createMockNode(), 0, 1]);
+      const $to = createResolvedPos(3);
       const range = new NodeRange($from, $to, 0);
 
       expect(range.start).toBe(1);
@@ -81,12 +76,15 @@ describe('NodeRange', () => {
   describe('end', () => {
     it('given depth 0, returns position after the last child at depth 1', () => {
       const childNode = createMockNode();
-      const $from = new ResolvedPos(1, [createMockNode(), 0, 0], 0);
-      const $to = new ResolvedPos(
-        3,
-        [createMockNode(), 0, 0, childNode, 0, 0],
-        0
-      );
+      const $from = createResolvedPos(1);
+      const $to = createResolvedPos(3, [
+        createMockNode(),
+        0,
+        0,
+        childNode,
+        0,
+        0,
+      ]);
       const range = new NodeRange($from, $to, 0);
 
       expect(range.end).toBe(childNode.nodeSize);
@@ -96,8 +94,8 @@ describe('NodeRange', () => {
   describe('parrent', () => {
     it('given depth 0, returns node at depth 0', () => {
       const node = createMockNode();
-      const $from = new ResolvedPos(1, [node, 0, 0], 0);
-      const $to = new ResolvedPos(3, [node, 0, 0], 0);
+      const $from = createResolvedPos(1, [node, 0, 0]);
+      const $to = createResolvedPos(3, [node, 0, 0]);
       const range = new NodeRange($from, $to, 0);
 
       expect(range.parent).toBe(node);
@@ -106,8 +104,8 @@ describe('NodeRange', () => {
 
   describe('startIndex', () => {
     it('given depth 0, returns $from index at depth', () => {
-      const $from = new ResolvedPos(1, [createMockNode(), 2, 0], 0);
-      const $to = new ResolvedPos(3, [createMockNode(), 0, 0], 0);
+      const $from = createResolvedPos(1, [createMockNode(), 2, 0]);
+      const $to = createResolvedPos(3);
       const range = new NodeRange($from, $to, 0);
 
       expect(range.startIndex).toBe(2);
@@ -116,8 +114,8 @@ describe('NodeRange', () => {
 
   describe('endIndex', () => {
     it('given depth 0, returns $to index at depth', () => {
-      const $from = new ResolvedPos(1, [createMockNode(), 0, 0], 0);
-      const $to = new ResolvedPos(3, [createMockNode(), 2, 3], 0);
+      const $from = createResolvedPos(1);
+      const $to = createResolvedPos(3, [createMockNode(), 2, 3]);
       const range = new NodeRange($from, $to, 0);
 
       expect(range.endIndex).toBe(2);

--- a/packages/core/document/src/lib/value-objects/NodeType.spec.ts
+++ b/packages/core/document/src/lib/value-objects/NodeType.spec.ts
@@ -1,154 +1,140 @@
 import { Fragment } from '../entities/Fragment';
 import { Node } from '../entities/Node';
-import { NodeSpec } from '../interfaces/SchemaSpec';
 import { ContentMatch } from './ContentMatch';
-import { MarkType } from './MarkType';
 import { NodeType } from './NodeType';
+import { Mark } from './Mark';
+import {
+  defaultMockSchema,
+  createNodeSpec,
+  createMockNodeType,
+  paragraphType,
+  headingType,
+  textType,
+  boldMarkType,
+  linkMarkType,
+  italicMarkType,
+  createMockNode,
+  mentionType,
+  createMark,
+} from '../../testing';
 
 describe('NodeType', () => {
   describe('Constructor', () => {
     it('constructor, given valid spec, stores name', () => {
-      const spec: NodeSpec = { attrs: {} };
-      const mockSchema = {} as never;
-
-      const nodeType = new NodeType('paragraph', mockSchema, spec);
+      const nodeType = new NodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec()
+      );
 
       expect(nodeType).toBeInstanceOf(NodeType);
       expect(nodeType.name).toBe('paragraph');
     });
 
     it('constructor, given valid spec, stores schema reference', () => {
-      const spec: NodeSpec = { attrs: {} };
-      const mockSchema = {} as never;
+      const nodeType = new NodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec()
+      );
 
-      const nodeType = new NodeType('paragraph', mockSchema, spec);
-
-      expect(nodeType.schema).toBe(mockSchema);
+      expect(nodeType.schema).toBe(defaultMockSchema);
     });
 
     it('constructor, given valid spec, stores spec', () => {
-      const spec: NodeSpec = { attrs: { level: { default: 1 } } };
-      const mockSchema = {} as never;
-
-      const nodeType = new NodeType('paragraph', mockSchema, spec);
+      const spec = createNodeSpec({ attrs: { level: { default: 1 } } });
+      const nodeType = new NodeType('paragraph', defaultMockSchema, spec);
 
       expect(nodeType.spec).toBe(spec);
     });
 
     it('given default, is null', () => {
-      const spec: NodeSpec = { attrs: { level: { default: 1 } } };
-      const mockSchema = {} as never;
-
-      const nodeType = new NodeType('paragraph', mockSchema, spec);
+      const nodeType = new NodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec({ attrs: { level: { default: 1 } } })
+      );
 
       expect(nodeType.contentMatch).toBe(null);
     });
 
     it('given default, is null', () => {
-      const spec: NodeSpec = { attrs: { level: { default: 1 } } };
-      const mockSchema = {} as never;
-
-      const nodeType = new NodeType('paragraph', mockSchema, spec);
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec({ attrs: { level: { default: 1 } } })
+      );
 
       expect(nodeType.inlineContent).toBe(null);
     });
 
     it('constructor, given empty name, throws error', () => {
-      const spec: NodeSpec = { attrs: {} };
-      const mockSchema = {} as never;
-
-      expect(() => new NodeType('', mockSchema, spec)).toThrow(
-        'NodeType name cannot be empty'
-      );
+      expect(
+        () => new NodeType('', defaultMockSchema, createNodeSpec())
+      ).toThrow('NodeType name cannot be empty');
     });
 
     it('constructor, given null name, throws error', () => {
-      const spec: NodeSpec = { attrs: {} };
-      const mockSchema = {} as never;
-
-      expect(() => new NodeType(null as never, mockSchema, spec)).toThrow(
-        'NodeType name cannot be empty'
-      );
+      expect(
+        () => new NodeType(null as never, defaultMockSchema, createNodeSpec())
+      ).toThrow('NodeType name cannot be empty');
     });
 
     it('constructor, given undefined name, throws error', () => {
-      const spec: NodeSpec = { attrs: {} };
-      const mockSchema = {} as never;
-
-      expect(() => new NodeType(undefined as never, mockSchema, spec)).toThrow(
-        'NodeType name cannot be empty'
-      );
+      expect(
+        () =>
+          new NodeType(undefined as never, defaultMockSchema, createNodeSpec())
+      ).toThrow('NodeType name cannot be empty');
     });
 
     it('constructor, given whitespace name, throws error', () => {
-      const spec: NodeSpec = { attrs: {} };
-      const mockSchema = {} as never;
-
-      expect(() => new NodeType('  ', mockSchema, spec)).toThrow(
-        'NodeType name cannot be empty'
-      );
+      expect(
+        () => new NodeType('  ', defaultMockSchema, createNodeSpec())
+      ).toThrow('NodeType name cannot be empty');
     });
 
     it('constructor, given null schema, throws error', () => {
-      const spec: NodeSpec = { attrs: {} };
-
-      expect(() => new NodeType('paragraph', null as never, spec)).toThrow(
-        'NodeType schema cannot be null'
-      );
+      expect(
+        () => new NodeType('paragraph', null as never, createNodeSpec())
+      ).toThrow('NodeType schema cannot be null');
     });
 
     it('constructor, given undefined schema, throws error', () => {
-      const spec: NodeSpec = { attrs: {} };
-
-      expect(() => new NodeType('paragraph', undefined as never, spec)).toThrow(
-        'NodeType schema cannot be undefined'
-      );
+      expect(
+        () => new NodeType('paragraph', undefined as never, createNodeSpec())
+      ).toThrow('NodeType schema cannot be undefined');
     });
 
     it('constructor, given null spec, throws error', () => {
-      const mockSchema = {} as never;
-
       expect(
-        () => new NodeType('paragraph', mockSchema, null as never)
+        () => new NodeType('paragraph', defaultMockSchema, null as never)
       ).toThrow('NodeType spec cannot be null');
     });
 
     it('constructor, given undefined spec, throws error', () => {
-      const mockSchema = {} as never;
-
       expect(
-        () => new NodeType('paragraph', mockSchema, undefined as never)
+        () => new NodeType('paragraph', defaultMockSchema, undefined as never)
       ).toThrow('NodeType spec cannot be undefined');
     });
   });
 
   describe('equals()', () => {
     it('equals, given same name, returns true', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: {} };
-
-      const nodeType1 = new NodeType('paragraph', mockSchema, spec);
-      const nodeType2 = new NodeType('paragraph', mockSchema, spec);
+      const nodeType1 = createMockNodeType();
+      const nodeType2 = createMockNodeType();
 
       expect(nodeType1.equals(nodeType2)).toBe(true);
     });
 
     it('equals, given different name, returns false', () => {
-      const mockSchema = {} as never;
-      const spec1: NodeSpec = { attrs: {} };
-      const spec2: NodeSpec = { attrs: { level: { default: 1 } } };
-
-      const nodeType1 = new NodeType('paragraph', mockSchema, spec1);
-      const nodeType2 = new NodeType('heading', mockSchema, spec2);
+      const nodeType1 = createMockNodeType('paragraph');
+      const nodeType2 = createMockNodeType('heading');
 
       expect(nodeType1.equals(nodeType2)).toBe(false);
     });
 
     it('equals, given null parameter, throws error', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: {} };
-
-      const nodeType = new NodeType('paragraph', mockSchema, spec);
+      const nodeType = createMockNodeType('paragraph');
 
       expect(() => nodeType.equals(null as never)).toThrow(
         'NodeType equals parameter cannot be null'
@@ -157,110 +143,172 @@ describe('NodeType', () => {
   });
 
   describe('allowsMarkType', () => {
-    const mockSchema = {} as never;
-
-    it('given null parameter, throws error', () => {
-      const nodeType = new NodeType('paragraph', mockSchema, {});
-      expect(() => nodeType.allowsMarkType(null as never)).toThrow(
-        'NodeType allowsMarkType parameter cannot be null'
+    it('given markSet is null, returns true', () => {
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec()
       );
+      nodeType.markSet = null;
+
+      expect(nodeType.allowsMarkType(boldMarkType)).toBe(true);
     });
 
-    it('given non-MarkType parameter, throws error', () => {
-      const nodeType = new NodeType('paragraph', mockSchema, {});
-      expect(() => nodeType.allowsMarkType('bold' as never)).toThrow(
-        'NodeType allowsMarkType parameter must be MarkType'
+    it('given markType is in markSet, returns true', () => {
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec()
       );
+      nodeType.markSet = [boldMarkType, linkMarkType];
+
+      expect(nodeType.allowsMarkType(boldMarkType)).toBe(true);
     });
 
-    it('given marks spec is undefined, returns true when inline is true', () => {
-      const nodeType = new NodeType('text', mockSchema, { inline: true });
-      const boldType = new MarkType('bold', mockSchema, {});
-      expect(nodeType.allowsMarkType(boldType)).toBe(true);
+    it('given markType is not in markSet, returns false', () => {
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec()
+      );
+      nodeType.markSet = [boldMarkType, linkMarkType];
+
+      expect(nodeType.allowsMarkType(italicMarkType)).toBe(false);
+    });
+  });
+
+  describe('allowsMarks', () => {
+    it('given markSet is null, returns true', () => {
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec()
+      );
+      nodeType.markSet = null;
+      const marks = [createMark(boldMarkType, { color: 'red' })];
+
+      expect(nodeType.allowsMarks(marks)).toBe(true);
     });
 
-    it('given marks spec is undefined, returns false when inline is false', () => {
-      const nodeType = new NodeType('paragraph', mockSchema, { inline: false });
-      const boldType = new MarkType('bold', mockSchema, {});
-      expect(nodeType.allowsMarkType(boldType)).toBe(false);
+    it('given all marks in markSet, returns true', () => {
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec()
+      );
+      nodeType.markSet = [boldMarkType, linkMarkType];
+      const marks = [
+        createMark(boldMarkType, { color: 'red' }),
+        createMark(linkMarkType, { href: 'https://example.com' }),
+      ];
+
+      expect(nodeType.allowsMarks(marks)).toBe(true);
+    });
+  });
+
+  describe('allowedMarks', () => {
+    it('given markSet is null, returns same reference', () => {
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec()
+      );
+      nodeType.markSet = null;
+
+      const marks = [
+        createMark(boldMarkType, { color: 'red' }),
+        createMark(linkMarkType, { href: 'https://example.com' }),
+      ];
+
+      expect(nodeType.allowedMarks(marks)).toBe(marks);
     });
 
-    it('given marks spec is undefined, returns false when inline is undefined', () => {
-      const nodeType = new NodeType('paragraph', mockSchema, {});
-      const boldType = new MarkType('bold', mockSchema, {});
-      expect(nodeType.allowsMarkType(boldType)).toBe(false);
+    it('given one mark not allowed, returns filtered marks', () => {
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec()
+      );
+      nodeType.markSet = [boldMarkType];
+      const marks = [
+        createMark(boldMarkType, { color: 'red' }),
+        createMark(linkMarkType, { href: 'https://example.com' }),
+      ];
+
+      expect(nodeType.allowedMarks(marks)).toEqual([
+        createMark(boldMarkType, { color: 'red' }),
+      ]);
     });
 
-    it('given marks spec is "_", returns true for any mark type', () => {
-      const nodeType = new NodeType('paragraph', mockSchema, { marks: '_' });
-      const boldType = new MarkType('bold', mockSchema, {});
-      const linkType = new MarkType('link', mockSchema, {});
-      expect(nodeType.allowsMarkType(boldType)).toBe(true);
-      expect(nodeType.allowsMarkType(linkType)).toBe(true);
+    it('given all marks allowed, returns same reference', () => {
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec()
+      );
+      nodeType.markSet = [boldMarkType, linkMarkType];
+      const marks = [
+        createMark(boldMarkType, { color: 'red' }),
+        createMark(linkMarkType, { href: 'https://example.com' }),
+      ];
+
+      expect(nodeType.allowedMarks(marks)).toBe(marks);
     });
 
-    it('given marks spec is "", returns false for any mark type', () => {
-      const nodeType = new NodeType('code_block', mockSchema, { marks: '' });
-      const boldType = new MarkType('bold', mockSchema, {});
-      expect(nodeType.allowsMarkType(boldType)).toBe(false);
-    });
+    it('given all marks not allowed, returns Mark.none', () => {
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec()
+      );
+      nodeType.markSet = [boldMarkType];
+      const marks = [
+        createMark(linkMarkType, { href: 'https://example.com' }),
+        createMark(italicMarkType, { color: 'blue' }),
+      ];
 
-    it('given marks spec is space-separated list, returns true for listed mark', () => {
-      const nodeType = new NodeType('paragraph', mockSchema, {
-        marks: 'bold italic',
-      });
-      const boldType = new MarkType('bold', mockSchema, {});
-      expect(nodeType.allowsMarkType(boldType)).toBe(true);
-    });
-
-    it('given marks spec is space-separated list, returns false for unlisted mark', () => {
-      const nodeType = new NodeType('paragraph', mockSchema, {
-        marks: 'bold italic',
-      });
-      const linkType = new MarkType('link', mockSchema, {});
-      expect(nodeType.allowsMarkType(linkType)).toBe(false);
+      expect(nodeType.allowedMarks(marks)).toBe(Mark.none);
     });
   });
 
   describe('isLeaf', () => {
-    it('given spec.leaf true, returns true', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: {}, leaf: true };
-      const nodeType = new NodeType('image', mockSchema, spec);
+    it('given contentMatch is ContentMatch.empty, returns true', () => {
+      const nodeType = createMockNodeType(
+        'image',
+        defaultMockSchema,
+        createNodeSpec()
+      );
+      nodeType.contentMatch = ContentMatch.empty;
 
-      const result = nodeType.isLeaf;
-
-      expect(result).toBe(true);
+      expect(nodeType.isLeaf).toBe(true);
     });
   });
 
   describe('isText', () => {
-    it('given spec.text true, returns true', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: {}, text: true };
-      const nodeType = new NodeType('paragraph', mockSchema, spec);
-
-      const result = nodeType.isText;
-
-      expect(result).toBe(true);
+    it('given name is "text", returns true', () => {
+      expect(textType.isText).toBe(true);
     });
   });
 
   describe('isBlock', () => {
     it('given spec without inline and text flags, returns true', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: {} };
-      const nodeType = new NodeType('paragraph', mockSchema, spec);
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec()
+      );
 
       expect(nodeType.isBlock).toBe(true);
+    });
+
+    it('given name is "text", returns false', () => {
+      expect(textType.isBlock).toBe(false);
     });
   });
 
   describe('isInline', () => {
     it('given spec without inline and text flags, returns false', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: {} };
-      const nodeType = new NodeType('paragraph', mockSchema, spec);
+      const nodeType = createMockNodeType();
 
       expect(nodeType.isInline).toBe(false);
     });
@@ -268,28 +316,28 @@ describe('NodeType', () => {
 
   describe('create()', () => {
     it('given text node type, throws error', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: {}, text: true };
-      const nodeType = new NodeType('text', mockSchema, spec);
-
-      expect(() => nodeType.create()).toThrow(
+      expect(() => textType.create()).toThrow(
         'NodeType.create cannot construct text nodes'
       );
     });
 
     it('given block type with no args, returns Node with defaults', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: {} };
-      const nodeType = new NodeType('paragraph', mockSchema, spec);
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec()
+      );
 
       expect(nodeType.create()).toBeInstanceOf(Node);
     });
 
     it('create, given attrs and content, returns Node with provided values', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: {} };
-      const nodeType = new NodeType('paragraph', mockSchema, spec);
-      const childNode = new Node(new NodeType('heading', mockSchema, spec), {
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec()
+      );
+      const childNode = new Node(headingType, {
         level: 2,
         visible: true,
       });
@@ -303,14 +351,16 @@ describe('NodeType', () => {
     });
 
     it('given array of nodes as content, wraps in Fragment', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: {} };
-      const nodeType = new NodeType('paragraph', mockSchema, spec);
-      const childNode1 = new Node(new NodeType('heading', mockSchema, spec), {
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec()
+      );
+      const childNode1 = new Node(headingType, {
         level: 1,
         visible: true,
       });
-      const childNode2 = new Node(new NodeType('paragraph', mockSchema, spec), {
+      const childNode2 = new Node(paragraphType, {
         level: 2,
         visible: true,
       });
@@ -325,12 +375,6 @@ describe('NodeType', () => {
 
   describe('validContent()', () => {
     it('given matching content, returns true', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: {} };
-
-      const headingType = new NodeType('heading', mockSchema, spec);
-      const paragraphType = new NodeType('paragraph', mockSchema, spec);
-
       const finalMatch = new ContentMatch(true, []);
       const match2 = new ContentMatch(false, [
         { type: paragraphType, next: finalMatch },
@@ -339,24 +383,22 @@ describe('NodeType', () => {
         { type: headingType, next: match2 },
       ]);
 
-      const nodeType = new NodeType('doc', mockSchema, spec);
+      const nodeType = createMockNodeType(
+        'doc',
+        defaultMockSchema,
+        createNodeSpec()
+      );
       nodeType.contentMatch = match1;
 
       const content = Fragment.from([
-        new Node(headingType, {}),
-        new Node(paragraphType, {}),
+        createMockNode(headingType),
+        createMockNode(paragraphType),
       ]);
 
       expect(nodeType.validContent(content)).toBe(true);
     });
 
     it('validContent, given null, throws error', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: {} };
-
-      const headingType = new NodeType('heading', mockSchema, spec);
-      const paragraphType = new NodeType('paragraph', mockSchema, spec);
-
       const finalMatch = new ContentMatch(true, []);
       const match2 = new ContentMatch(false, [
         { type: paragraphType, next: finalMatch },
@@ -365,7 +407,11 @@ describe('NodeType', () => {
         { type: headingType, next: match2 },
       ]);
 
-      const nodeType = new NodeType('doc', mockSchema, spec);
+      const nodeType = createMockNodeType(
+        'doc',
+        defaultMockSchema,
+        createNodeSpec()
+      );
       nodeType.contentMatch = match1;
 
       expect(() => nodeType.validContent(null as never)).toThrow(
@@ -374,12 +420,6 @@ describe('NodeType', () => {
     });
 
     it('validContent, given undefined, throws error', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: {} };
-
-      const headingType = new NodeType('heading', mockSchema, spec);
-      const paragraphType = new NodeType('paragraph', mockSchema, spec);
-
       const finalMatch = new ContentMatch(true, []);
       const match2 = new ContentMatch(false, [
         { type: paragraphType, next: finalMatch },
@@ -388,26 +428,98 @@ describe('NodeType', () => {
         { type: headingType, next: match2 },
       ]);
 
-      const nodeType = new NodeType('doc', mockSchema, spec);
+      const nodeType = createMockNodeType(
+        'doc',
+        defaultMockSchema,
+        createNodeSpec()
+      );
       nodeType.contentMatch = match1;
 
       expect(() => nodeType.validContent(undefined as never)).toThrow(
         'NodeType validContent parameter cannot be undefined'
       );
     });
+
+    it('given content with disallowed marks, returns false', () => {
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec()
+      );
+      nodeType.contentMatch = ContentMatch.parse('paragraph', {
+        paragraph: paragraphType,
+      });
+      nodeType.markSet = [boldMarkType];
+
+      const content = Fragment.from([
+        new Node(paragraphType, {}, undefined, [
+          createMark(linkMarkType, { href: 'https://example.com' }),
+        ]),
+      ]);
+
+      expect(nodeType.validContent(content)).toBe(false);
+    });
+  });
+
+  describe('createChecked()', () => {
+    it('given valid content, returns node', () => {
+      const finalMatch = new ContentMatch(true, []);
+      const match2 = new ContentMatch(false, [
+        { type: paragraphType, next: finalMatch },
+      ]);
+      const match1 = new ContentMatch(false, [
+        { type: headingType, next: match2 },
+      ]);
+
+      const nodeType = createMockNodeType(
+        'doc',
+        defaultMockSchema,
+        createNodeSpec()
+      );
+      nodeType.contentMatch = match1;
+
+      const content = Fragment.from([
+        createMockNode(headingType),
+        createMockNode(paragraphType),
+      ]);
+
+      const node = nodeType.createChecked({}, content);
+
+      expect(node).toBeInstanceOf(Node);
+    });
+
+    it('given invalid content, throws RangeError', () => {
+      const finalMatch = new ContentMatch(true, []);
+      const match2 = new ContentMatch(false, [
+        { type: paragraphType, next: finalMatch },
+      ]);
+      const match1 = new ContentMatch(false, [
+        { type: headingType, next: match2 },
+      ]);
+
+      const nodeType = createMockNodeType(
+        'doc',
+        defaultMockSchema,
+        createNodeSpec()
+      );
+      nodeType.contentMatch = match1;
+
+      const content = Fragment.from([
+        createMockNode(paragraphType),
+        createMockNode(headingType),
+      ]);
+
+      expect(() => nodeType.createChecked({}, content)).toThrow(RangeError);
+    });
   });
 
   describe('hasRequiredAttrs()', () => {
     it('given one attr without default, returns true', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = {
-        attrs: {
-          title: { default: 'Untitled' },
-          level: {},
-        },
-      };
-
-      const nodeType = new NodeType('heading', mockSchema, spec);
+      const nodeType = createMockNodeType(
+        'heading',
+        defaultMockSchema,
+        createNodeSpec({ attrs: { title: { default: 'Untitled' }, level: {} } })
+      );
 
       expect(nodeType.hasRequiredAttrs()).toBe(true);
     });
@@ -415,9 +527,11 @@ describe('NodeType', () => {
 
   describe('isTextblock()', () => {
     it('given block node with inlineContent true, returns true', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: {} };
-      const nodeType = new NodeType('paragraph', mockSchema, spec);
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec()
+      );
       nodeType.inlineContent = true;
 
       expect(nodeType.isTextblock).toBe(true);
@@ -426,55 +540,51 @@ describe('NodeType', () => {
 
   describe('isAtom()', () => {
     it('given leaf node, returns true', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: {}, leaf: true };
-      const nodeType = new NodeType('image', mockSchema, spec);
+      const nodeType = createMockNodeType(
+        'image',
+        defaultMockSchema,
+        createNodeSpec()
+      );
+      nodeType.contentMatch = ContentMatch.empty;
 
       expect(nodeType.isAtom).toBe(true);
     });
 
     it('given non-leaf node with atom spec true, returns true', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: {}, atom: true };
-      const nodeType = new NodeType('image', mockSchema, spec);
-
-      expect(nodeType.isAtom).toBe(true);
+      expect(mentionType.isAtom).toBe(true);
     });
   });
 
   describe('createAndFill()', () => {
     it('given text node type, throws error', () => {
-      const mockSchema = {} as never;
-      const spec: NodeSpec = { attrs: {}, text: true };
-      const nodeType = new NodeType('text', mockSchema, spec);
-
-      expect(() => nodeType.createAndFill()).toThrow(
+      expect(() => textType.createAndFill()).toThrow(
         'NodeType.createAndFill cannot construct text nodes'
       );
     });
 
     it('given content that cannot be filled, returns null', () => {
-      const paragraphType = new NodeType('paragraph', {} as never, {
-        attrs: {},
-      });
-      const headingType = new NodeType('heading', {} as never, { attrs: {} });
-
       const finalMatch = new ContentMatch(true, []);
       const match = new ContentMatch(false, [
         { type: paragraphType, next: finalMatch },
       ]);
 
-      const nodeType = new NodeType('doc', {} as never, { attrs: {} });
+      const nodeType = createMockNodeType(
+        'doc',
+        defaultMockSchema,
+        createNodeSpec()
+      );
       nodeType.contentMatch = match;
 
-      const content = Fragment.from([new Node(headingType, {})]);
+      const content = Fragment.from([createMockNode(headingType)]);
       const result = nodeType.createAndFill({}, content);
 
       expect(result).toBe(null);
     });
 
     it('given empty content and valid contentMatch, returns node', () => {
-      const nodeType = new NodeType('doc', {} as never, { attrs: {} });
+      const nodeType = createMockNodeType('doc', defaultMockSchema, {
+        attrs: {},
+      });
       nodeType.contentMatch = new ContentMatch(true, []);
 
       const result = nodeType.createAndFill();
@@ -483,11 +593,6 @@ describe('NodeType', () => {
     });
 
     it('given non-empty content that needs fill, returns node with complete content', () => {
-      const paragraphType = new NodeType('paragraph', {} as never, {
-        attrs: {},
-      });
-      const headingType = new NodeType('heading', {} as never, { attrs: {} });
-
       const finalMatch = new ContentMatch(true, []);
       const match2 = new ContentMatch(false, [
         { type: paragraphType, next: finalMatch },
@@ -496,14 +601,67 @@ describe('NodeType', () => {
         { type: headingType, next: match2 },
       ]);
 
-      const nodeType = new NodeType('doc', {} as never, { attrs: {} });
+      const nodeType = createMockNodeType('doc', defaultMockSchema, {
+        attrs: {},
+      });
       nodeType.contentMatch = match1;
 
-      const content = Fragment.from([new Node(paragraphType, {})]);
+      const content = Fragment.from([createMockNode(paragraphType)]);
       const result = nodeType.createAndFill({}, content);
 
       expect(result).toBeInstanceOf(Node);
       expect(result?.content.childCount).toBe(2);
+    });
+  });
+
+  describe('compatibleContent', () => {
+    it('given same type, returns true', () => {
+      const nodeType = createMockNodeType();
+      nodeType.contentMatch = ContentMatch.parse('paragraph', {
+        paragraph: nodeType,
+      });
+
+      expect(nodeType.compatibleContent(nodeType)).toBe(true);
+    });
+
+    it('given compatible contentMatch, returns true', () => {
+      const nodeType1 = createMockNodeType('paragraph');
+      const nodeType2 = createMockNodeType('paragraph');
+
+      const match1 = ContentMatch.parse('paragraph', {
+        paragraph: nodeType1,
+      });
+
+      const match2 = ContentMatch.parse('paragraph', {
+        paragraph: nodeType1,
+      });
+
+      nodeType1.contentMatch = match1;
+      nodeType2.contentMatch = match2;
+
+      expect(nodeType1.compatibleContent(nodeType2)).toBe(true);
+    });
+  });
+
+  describe('whitespace()', () => {
+    it('given spec.whitespace "pre", returns "pre"', () => {
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec({ whitespace: 'pre' })
+      );
+
+      expect(nodeType.whitespace).toBe('pre');
+    });
+
+    it('given spec.code true, returns "pre"', () => {
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec({ code: true })
+      );
+
+      expect(nodeType.whitespace).toBe('pre');
     });
   });
 });

--- a/packages/core/document/src/lib/value-objects/NodeType.ts
+++ b/packages/core/document/src/lib/value-objects/NodeType.ts
@@ -42,46 +42,39 @@ export class NodeType {
   }
 
   allowsMarkType(markType: MarkType): boolean {
-    if (markType === null) {
-      throw new Error('NodeType allowsMarkType parameter cannot be null');
+    return this.markSet === null || this.markSet.indexOf(markType) > -1;
+  }
+
+  allowsMarks(marks: Mark[]): boolean {
+    if (this.markSet === null) return true;
+    return marks.every(
+      (mark) => this.markSet && this.markSet.indexOf(mark.type) > -1
+    );
+  }
+
+  allowedMarks(marks: readonly Mark[]): readonly Mark[] {
+    if (this.markSet === null) return marks;
+    let copy: Mark[] | null = null;
+    for (let i = 0; i < marks.length; i++) {
+      if (this.markSet.indexOf(marks[i].type) > -1) {
+        if (copy) copy.push(marks[i] as Mark);
+      } else {
+        if (!copy) copy = marks.slice(0, i) as Mark[];
+      }
     }
-
-    if (!(markType instanceof MarkType)) {
-      throw new Error('NodeType allowsMarkType parameter must be MarkType');
-    }
-
-    const marks = this.spec.marks;
-
-    // marks tanımsız → inline ise tümüne izin, değilse hiçbirine
-    if (marks === undefined) {
-      return this.spec.inline === true;
-    }
-
-    // "_" → tüm marklara izin
-    if (marks === '_') {
-      return true;
-    }
-
-    // "" → hiçbir marka izin yok
-    if (marks === '') {
-      return false;
-    }
-
-    // "bold italic link" → listedekilere izin
-    const allowedMarks = marks.split(' ');
-    return allowedMarks.includes(markType.name);
+    return !copy ? marks : copy.length ? copy : Mark.none;
   }
 
   get isLeaf(): boolean {
-    return this.spec.leaf === true;
+    return this.contentMatch === ContentMatch.empty;
   }
 
   get isText(): boolean {
-    return this.spec.text === true;
+    return this.name === 'text';
   }
 
   get isBlock(): boolean {
-    return !(this.spec.text || this.spec.inline);
+    return !(this.name === 'text' || this.spec.inline);
   }
 
   get isInline(): boolean {
@@ -94,6 +87,10 @@ export class NodeType {
 
   get isAtom(): boolean {
     return this.isLeaf || this.spec.atom === true;
+  }
+
+  get whitespace(): 'normal' | 'pre' {
+    return this.spec.code ? 'pre' : this.spec.whitespace || 'normal';
   }
 
   create(
@@ -160,7 +157,30 @@ export class NodeType {
 
     const result = this.contentMatch?.matchFragment(content);
     if (!result || !result.validEnd) return false;
+
+    for (let i = 0; i < content.childCount; i++) {
+      if (!this.allowsMarks(content.child(i).marks)) return false
+    }
+
     return true;
+  }
+
+  createChecked(attrs?: Record<string, unknown>, content?: Fragment<Node> | Node[], marks?: Mark[]): Node {
+    const node = this.create(attrs, content, marks);
+    this.checkContent(node.content);
+    return node;
+  }
+
+  compatibleContent(other: NodeType): boolean {
+    return this === other || this.contentMatch?.compatible(other.contentMatch ?? ContentMatch.empty) === true;
+  }
+
+  private checkContent(content: Fragment<Node>): void {
+    if (!this.validContent(content)) {
+      throw new RangeError(
+        `Invalid content for node ${this.name}: ${content.toString()}`
+      );
+    }
   }
 
   private validateParameter(paramName: string, paramValue: unknown): void {

--- a/packages/core/document/src/lib/value-objects/ResolvedPos.spec.ts
+++ b/packages/core/document/src/lib/value-objects/ResolvedPos.spec.ts
@@ -1,12 +1,9 @@
 import { Fragment } from '../entities/Fragment';
 import { Node } from '../entities/Node';
-import { NodeType } from './NodeType';
 import { ResolvedPos } from './ResolvedPos';
+import { createMockNode } from '../../testing';
 
 const path: (Node | number)[] = [];
-
-const createMockNode = (name = 'paragraph'): Node =>
-  new Node(new NodeType(name, {} as never, { attrs: {} }), {});
 
 describe('ResolvedPos', () => {
   describe('constructor', () => {
@@ -392,24 +389,6 @@ describe('ResolvedPos', () => {
       expect(resolvedPos?.nodeAfter).toBeNull();
     });
 
-    /* it('given pos inside text node, returns remaining text node', () => {
-      const textNode = new Node(
-        new NodeType('text', {} as never, { attrs: {}, text: true }),
-        {},
-        undefined,
-        [],
-        'hello'
-      );
-      const rootNode = new Node(
-        createMockNode().type,
-        {},
-        Fragment.from([textNode])
-      );
-      const resolvedPos = ResolvedPos.resolve(rootNode, 2);
-
-      expect(resolvedPos?.nodeAfter?.text).toBe('llo');
-    }); */
-
     it('given pos between nodes, returns full next node', () => {
       const firstNode = createMockNode();
       const secondNode = createMockNode();
@@ -436,23 +415,5 @@ describe('ResolvedPos', () => {
 
       expect(resolvedPos?.nodeBefore).toBeNull();
     });
-
-    /* it('given pos inside text node, returns preceding text node', () => {
-      const textNode = new Node(
-        new NodeType('text', {} as never, { attrs: {}, text: true }),
-        {},
-        undefined,
-        [],
-        'hello'
-      );
-      const rootNode = new Node(
-        createMockNode().type,
-        {},
-        Fragment.from([textNode])
-      );
-      const resolvedPos = ResolvedPos.resolve(rootNode, 2);
-
-      expect(resolvedPos?.nodeBefore?.text).toBe('he');
-    }); */
   });
 });

--- a/packages/core/document/src/lib/value-objects/Slice.spec.ts
+++ b/packages/core/document/src/lib/value-objects/Slice.spec.ts
@@ -1,14 +1,12 @@
 import { Fragment } from '../entities/Fragment';
 import { Node } from '../entities/Node';
 import { Slice } from './Slice';
-
-const content = Fragment.empty<Node>();
-const nonEmptyContent = { size: 3 } as Fragment<Node>;
+import { emptyContent, nonEmptyContent } from '../../testing';
 
 describe('Slice Value Object', () => {
   describe('constructor', () => {
     it('returns Slice instance', () => {
-      const slice = new Slice(content, 0, 0);
+      const slice = new Slice(emptyContent, 0, 0);
 
       expect(slice).toBeInstanceOf(Slice);
     });
@@ -26,43 +24,43 @@ describe('Slice Value Object', () => {
     });
 
     it('given negative openStart, throws "Slice openStart cannot be negative"', () => {
-      expect(() => new Slice(content, -1, 0)).toThrow(
+      expect(() => new Slice(emptyContent, -1, 0)).toThrow(
         'Slice openStart cannot be negative'
       );
     });
 
     it('given negative openEnd, throws "Slice openEnd cannot be negative"', () => {
-      expect(() => new Slice(content, 0, -1)).toThrow(
+      expect(() => new Slice(emptyContent, 0, -1)).toThrow(
         'Slice openEnd cannot be negative'
       );
     });
 
     it('given float openStart, throws "Slice openStart must be an integer"', () => {
-      expect(() => new Slice(content, 1.7, 0)).toThrow(
+      expect(() => new Slice(emptyContent, 1.7, 0)).toThrow(
         'Slice openStart must be an integer'
       );
     });
 
     it('given float openEnd, throws "Slice openEnd must be an integer"', () => {
-      expect(() => new Slice(content, 1, 0.3)).toThrow(
+      expect(() => new Slice(emptyContent, 1, 0.3)).toThrow(
         'Slice openEnd must be an integer'
       );
     });
 
     it('throws error when openEnd is less than openStart', () => {
-      expect(() => new Slice(content, 2, 1)).toThrow(
+      expect(() => new Slice(emptyContent, 2, 1)).toThrow(
         'Slice openEnd cannot be less than openStart'
       );
     });
 
     it('throws error when empty fragment has non-zero openStart', () => {
-      expect(() => new Slice(content, 1, 1)).toThrow(
+      expect(() => new Slice(emptyContent, 1, 1)).toThrow(
         'Slice with empty content must have zero opens'
       );
     });
 
     it('throws error when empty fragment has non-zero openEnd', () => {
-      expect(() => new Slice(content, 1, 2)).toThrow(
+      expect(() => new Slice(emptyContent, 1, 2)).toThrow(
         'Slice with empty content must have zero opens'
       );
     });
@@ -101,9 +99,9 @@ describe('Slice Value Object', () => {
 
   describe('size', () => {
     it('returns content.childCount', () => {
-      const slice = new Slice(content, 0, 0);
+      const slice = new Slice(emptyContent, 0, 0);
 
-      expect(slice.size).toBe(content.childCount);
+      expect(slice.size).toBe(emptyContent.childCount);
     });
   });
 

--- a/packages/core/document/src/testing/index.ts
+++ b/packages/core/document/src/testing/index.ts
@@ -1,0 +1,109 @@
+import { Node } from '../lib/entities/Node';
+import { Fragment } from '../lib/entities/Fragment';
+import { ContentMatch } from '../lib/value-objects/ContentMatch';
+import { NodeType } from '../lib/value-objects/NodeType';
+import { MarkType } from '../lib/value-objects/MarkType';
+import { Mark } from '../lib/value-objects/Mark';
+import { MarkSpec, NodeSpec } from '../lib/interfaces/SchemaSpec';
+import { Edge } from '../lib/interfaces/Edge';
+import { ResolvedPos } from '../lib/value-objects/ResolvedPos';
+
+// — Defaults
+export const defaultMockSchema = {} as never;
+export const defaultNodeSpec: NodeSpec = { attrs: {} };
+export const defaultMarkSpec: MarkSpec = { attrs: {} };
+
+// — NodeType instances
+export const paragraphType = new NodeType('paragraph', defaultMockSchema, defaultNodeSpec);
+export const textType = new NodeType('text', defaultMockSchema, defaultNodeSpec);
+export const imageType = new NodeType('image', defaultMockSchema, defaultNodeSpec);
+export const headingType = new NodeType('heading', defaultMockSchema, defaultNodeSpec);
+export const spanType = new NodeType('span', defaultMockSchema, { attrs: {}, inline: true });
+export const mentionType = new NodeType('span', defaultMockSchema, { attrs: {}, atom: true });
+
+// — MarkType instances
+export const boldMarkType = new MarkType('bold', defaultMockSchema, defaultMarkSpec);
+export const italicMarkType = new MarkType('italic', defaultMockSchema, defaultMarkSpec);
+export const linkMarkType = new MarkType('link', defaultMockSchema, defaultMarkSpec);
+
+// — Shared Node setup
+export const mockChildNode = new Node(paragraphType, { attrs: {} });
+export const mockContent = Fragment.from<Node>([mockChildNode]);
+
+// — Fragment helpers
+export const emptyContent = Fragment.empty<Node>();
+export const nonEmptyContent = { size: 3 } as Fragment<Node>;
+
+// — Spec factories
+export const createNodeSpec = (attrs = { attrs: {} } as NodeSpec): NodeSpec =>
+  attrs as unknown as NodeSpec;
+
+export function createSchemaSpec(
+  extra?: Record<string, NodeSpec>
+): Record<string, NodeSpec> {
+  return {
+    doc: { content: 'paragraph+' },
+    text: {  },
+    paragraph: { attrs: {} },
+    heading: { attrs: {} },
+    ...extra,
+  };
+}
+
+export function createMarkSpec(
+  extra?: Record<string, MarkSpec>
+): Record<string, MarkSpec> {
+  return {
+    strong: { attrs: {} },
+    em: { attrs: {} },
+    ...extra,
+  };
+}
+
+// — ResolvedPos factory
+export function createResolvedPos(
+  pos: number,
+  path: (Node | number)[] = [createMockNode(), 0, 0],
+  parentOffset = 0
+): ResolvedPos {
+  return new ResolvedPos(pos, path, parentOffset);
+}
+
+// — Mark factories
+export const createMarkType = (name: string, schema: unknown, spec: MarkSpec) =>
+  new MarkType(name, schema, spec);
+
+export const createMark = (type: MarkType, attrs: Record<string, unknown>) =>
+  new Mark(type, attrs);
+
+export function createMarks(...types: string[]): Mark[] {
+  return types.map((t) => new Mark(new MarkType(t, {}, {}), {}));
+}
+
+// — Mock factories
+export function createMockNodeType(
+  name = 'paragraph',
+  schema: unknown = {},
+  spec: NodeSpec = { attrs: { content: { default: 'text*' } } }
+): NodeType {
+  return new NodeType(name, schema, spec);
+}
+
+export function createMockContentMatch(
+  validEnd = true,
+  edges: Edge[] = []
+): ContentMatch {
+  return new ContentMatch(validEnd, edges);
+}
+
+export function createMockNode(nameOrType: string | NodeType = 'paragraph'): Node {
+  const nodeType =
+    typeof nameOrType === 'string'
+      ? new NodeType(nameOrType, {}, { attrs: {} })
+      : nameOrType;
+  return new Node(nodeType, {});
+}
+
+export function createMockFragment(nodes: Node[] = []): Fragment<Node> {
+  return nodes.length === 0 ? Fragment.empty() : Fragment.from(nodes);
+}

--- a/packages/core/document/tsconfig.lib.json
+++ b/packages/core/document/tsconfig.lib.json
@@ -17,6 +17,7 @@
   "exclude": [
     "jest.config.ts",
     "jest.config.cts",
+    "src/testing/**/*",
     "src/**/*.spec.ts",
     "src/**/*.test.ts"
   ]

--- a/packages/core/document/tsconfig.spec.json
+++ b/packages/core/document/tsconfig.spec.json
@@ -12,6 +12,7 @@
     "jest.config.cts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
+    "src/testing/**/*",
     "src/**/*.d.ts"
   ],
   "references": [


### PR DESCRIPTION
- Reimplement allowsMarkType() using markSet
- Add allowsMarks() method
- Add allowedMarks() method
- Fix validContent() to check per-child marks
- Add createChecked() method
- Add compatibleContent() method
- Add whitespace getter
- Add code and whitespace fields to NodeSpec

Issue #55