### PR TITLE
feat(document): implement ReplaceError and Slice API completion (#57)

### DIFF
--- a/packages/core/document/src/index.ts
+++ b/packages/core/document/src/index.ts
@@ -1,5 +1,8 @@
 export * from './lib/document';
 
+// Errors
+export { ReplaceError } from './lib/errors/ReplaceError';
+
 // Entities
 export { Fragment } from './lib/entities/Fragment';
 export { Node } from './lib/entities/Node';

--- a/packages/core/document/src/lib/errors/ReplaceError.spec.ts
+++ b/packages/core/document/src/lib/errors/ReplaceError.spec.ts
@@ -1,0 +1,7 @@
+import { ReplaceError } from './ReplaceError';
+describe('ReplaceError', () => {
+  it('given valid message, creates an instance of ReplaceError', () => {
+    const error = new ReplaceError('This is a replace error');
+    expect(error).toBeInstanceOf(ReplaceError);
+  });
+});

--- a/packages/core/document/src/lib/errors/ReplaceError.ts
+++ b/packages/core/document/src/lib/errors/ReplaceError.ts
@@ -1,0 +1,1 @@
+export class ReplaceError extends Error {}

--- a/packages/core/document/src/lib/interfaces/SchemaSpec.ts
+++ b/packages/core/document/src/lib/interfaces/SchemaSpec.ts
@@ -11,6 +11,7 @@ export interface NodeSpec {
   content?: string;
   group?: string;
   inline?: boolean;
+  isolating?: boolean;
   marks?: string;
   whitespace?: 'normal' | 'pre';
 }

--- a/packages/core/document/src/lib/value-objects/NodeType.ts
+++ b/packages/core/document/src/lib/value-objects/NodeType.ts
@@ -175,7 +175,7 @@ export class NodeType {
     return this === other || this.contentMatch?.compatible(other.contentMatch ?? ContentMatch.empty) === true;
   }
 
-  private checkContent(content: Fragment<Node>): void {
+  checkContent(content: Fragment<Node>): void {
     if (!this.validContent(content)) {
       throw new RangeError(
         `Invalid content for node ${this.name}: ${content.toString()}`

--- a/packages/core/document/src/lib/value-objects/Slice.spec.ts
+++ b/packages/core/document/src/lib/value-objects/Slice.spec.ts
@@ -1,7 +1,15 @@
 import { Fragment } from '../entities/Fragment';
 import { Node } from '../entities/Node';
 import { Slice } from './Slice';
-import { emptyContent, nonEmptyContent } from '../../testing';
+import {
+  createMockNode,
+  paragraphType,
+  headingType,
+  emptyContent,
+  nonEmptyContent,
+  createMockNodeType,
+} from '../../testing';
+import { ContentMatch } from './ContentMatch';
 
 describe('Slice Value Object', () => {
   describe('constructor', () => {
@@ -68,40 +76,63 @@ describe('Slice Value Object', () => {
 
   describe('equals', () => {
     it('returns true when all properties match', () => {
-      const slice1 = new Slice(nonEmptyContent, 1, 2);
-      const slice2 = new Slice(nonEmptyContent, 1, 2);
+      const node = createMockNode(paragraphType);
+      const content = Fragment.from<Node>([node]);
+      const slice1 = new Slice(content, 1, 2);
+      const slice2 = new Slice(content, 1, 2);
 
       expect(slice1.equals(slice2)).toBe(true);
     });
 
     it('returns false when content differs', () => {
-      const content2 = { size: 5 } as Fragment<Node>;
-      const slice1 = new Slice(nonEmptyContent, 1, 2);
+      const content1 = Fragment.from<Node>([createMockNode(paragraphType)]);
+      const content2 = Fragment.from<Node>([createMockNode(headingType)]);
+      const slice1 = new Slice(content1, 1, 2);
       const slice2 = new Slice(content2, 1, 2);
 
       expect(slice1.equals(slice2)).toBe(false);
     });
 
     it('returns false when openStart differs', () => {
-      const slice1 = new Slice(nonEmptyContent, 1, 2);
-      const slice2 = new Slice(nonEmptyContent, 2, 2);
+      const node = createMockNode(paragraphType);
+      const content = Fragment.from<Node>([node]);
+      const slice1 = new Slice(content, 1, 2);
+      const slice2 = new Slice(content, 2, 2);
 
       expect(slice1.equals(slice2)).toBe(false);
     });
 
     it('returns false when openEnd differs', () => {
-      const slice1 = new Slice(nonEmptyContent, 1, 2);
-      const slice2 = new Slice(nonEmptyContent, 1, 3);
+      const node = createMockNode(paragraphType);
+      const content = Fragment.from<Node>([node]);
+      const slice1 = new Slice(content, 1, 2);
+      const slice2 = new Slice(content, 1, 3);
 
       expect(slice1.equals(slice2)).toBe(false);
+    });
+
+    it('given structurally equal content but different references, returns true', () => {
+      const node = createMockNode(paragraphType);
+      const content1 = Fragment.from<Node>([node]);
+      const content2 = Fragment.from<Node>([node]);
+      const slice1 = new Slice(content1, 1, 2);
+      const slice2 = new Slice(content2, 1, 2);
+
+      expect(slice1.equals(slice2)).toBe(true);
     });
   });
 
   describe('size', () => {
-    it('returns content.childCount', () => {
+    it('given zero opens, returns content.size', () => {
       const slice = new Slice(emptyContent, 0, 0);
 
       expect(slice.size).toBe(emptyContent.childCount);
+    });
+
+    it('given non-zero openStart and openEnd, returns content.size minus openStart and openEnd', () => {
+      const slice = new Slice(nonEmptyContent, 1, 2);
+
+      expect(slice.size).toBe(nonEmptyContent.size - 3);
     });
   });
 
@@ -113,6 +144,45 @@ describe('Slice Value Object', () => {
     it('has Fragment.empty content and zero opens', () => {
       expect(Slice.empty.openStart).toBe(0);
       expect(Slice.empty.openEnd).toBe(0);
+    });
+  });
+
+  describe('toString', () => {
+    it('given non-empty slice, returns content string with open depths', () => {
+      const node = createMockNode(paragraphType);
+      const content = Fragment.from<Node>([node]);
+      const slice = new Slice(content, 1, 2);
+
+      expect(slice.toString()).toBe(`${content.toString()}(1,2)`);
+    });
+  });
+
+  describe('maxOpen', () => {
+    it('given fragment with non-leaf first and last children, returns slice with correct open depths', () => {
+      const node1 = createMockNode(paragraphType);
+      const node2 = createMockNode(headingType);
+      const content = Fragment.from<Node>([node1, node2]);
+      const slice = Slice.maxOpen(content);
+
+      expect(slice.openStart).toBe(1);
+      expect(slice.openEnd).toBe(1);
+    });
+
+    it('given fragment with leaf first child, returns openStart 0', () => {
+      const leafType = createMockNodeType('image');
+      leafType.contentMatch = ContentMatch.empty;
+      const node = createMockNode(leafType);
+      const content = Fragment.from<Node>([node]);
+      const slice = Slice.maxOpen(content);
+
+      expect(slice.openStart).toBe(0);
+    });
+
+    it('given empty fragment, returns slice with zero opens', () => {
+      const slice = Slice.maxOpen(Fragment.empty());
+
+      expect(slice.openStart).toBe(0);
+      expect(slice.openEnd).toBe(0);
     });
   });
 });

--- a/packages/core/document/src/lib/value-objects/Slice.ts
+++ b/packages/core/document/src/lib/value-objects/Slice.ts
@@ -12,16 +12,38 @@ export class Slice {
     Slice.validateParameters(content, openStart, openEnd);
   }
 
+  static maxOpen(fragment: Fragment<Node>, openIsolating = true): Slice {
+    let openStart = 0,
+      openEnd = 0;
+    for (
+      let n = fragment.firstChild;
+      n && !n.isLeaf && (openIsolating || !n.type.spec.isolating);
+      n = n.firstChild
+    )
+      openStart++;
+    for (
+      let n = fragment.lastChild;
+      n && !n.isLeaf && (openIsolating || !n.type.spec.isolating);
+      n = n.lastChild
+    )
+      openEnd++;
+    return new Slice(fragment, openStart, openEnd);
+  }
+
+  get size(): number {
+    return this.content.size - this.openStart - this.openEnd;
+  }
+
   equals(other: Slice): boolean {
     return (
-      this.content === other.content &&
+      this.content.equals(other.content) &&
       this.openStart === other.openStart &&
       this.openEnd === other.openEnd
     );
   }
 
-  get size(): number {
-    return this.content.size;
+  toString(): string {
+    return `${this.content.toString()}(${this.openStart},${this.openEnd})`;
   }
 
   private static validateParameters(


### PR DESCRIPTION
- Add ReplaceError class
- Fix Slice.size: content.size - openStart - openEnd
- Fix Slice.equals: structural comparison via content.equals()
- Add Slice.toString()
- Add Slice.maxOpen()
- Add NodeSpec.isolating optional field
- Make NodeType.checkContent() public