### PR TITLE
feat(document): implement Slice.insertAt, removeBetween, Fragment.cut…

### DIFF
--- a/packages/core/document/src/lib/entities/Fragment.spec.ts
+++ b/packages/core/document/src/lib/entities/Fragment.spec.ts
@@ -469,6 +469,15 @@ describe('Fragment', () => {
       expect(result.child(0).content.childCount).toBe(1);
       expect(result.child(0).content.child(0)).toBe(child1);
     });
+
+    it('given range cutting into a text node, returns trimmed text node', () => {
+      const text = new TextNode(textType, {}, 'helloworld');
+      const fragment = Fragment.from([text]);
+
+      const result = fragment.cut(2, 7);
+
+      expect((result.child(0) as TextNode).text).toBe('llowo');
+    });
   });
 
   describe('append', () => {

--- a/packages/core/document/src/lib/entities/Fragment.ts
+++ b/packages/core/document/src/lib/entities/Fragment.ts
@@ -112,10 +112,20 @@ export class Fragment<TNode extends Node> {
         const end = pos + child.nodeSize;
         if (end > from) {
           if (pos < from || end > to) {
-            child = child.cut(
-              Math.max(0, from - pos - 1),
-              Math.min(child.content.size, to - pos - 1)
-            ) as TNode;
+            if (child.isText) {
+              child = child.cut(
+                Math.max(0, from - pos),
+                Math.min(
+                  (child as unknown as { text: string }).text.length,
+                  to - pos
+                )
+              ) as TNode;
+            } else {
+              child = child.cut(
+                Math.max(0, from - pos - 1),
+                Math.min(child.content.size, to - pos - 1)
+              ) as TNode;
+            }
           }
           result.push(child);
         }

--- a/packages/core/document/src/lib/entities/Node.spec.ts
+++ b/packages/core/document/src/lib/entities/Node.spec.ts
@@ -434,4 +434,61 @@ describe('Node', () => {
       expect(node.toString()).toBe('paragraph');
     });
   });
+
+  describe('canReplace', () => {
+    it('given valid replacement matching content, returns true', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph', {
+        paragraph: paragraphType,
+      });
+
+      const child = new Node(paragraphType, {});
+      const node = new Node(nodeType, {}, Fragment.from([child]), []);
+      const replacement = Fragment.from([new Node(paragraphType, {})]);
+
+      expect(node.canReplace(0, 1, replacement)).toBe(true);
+    });
+
+    it('given replacement that breaks content model, returns false', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph', {
+        paragraph: paragraphType,
+      });
+
+      const child = new Node(paragraphType, {});
+      const node = new Node(nodeType, {}, Fragment.from([child]), []);
+      const replacement = Fragment.from([new Node(headingType, {})]);
+
+      expect(node.canReplace(0, 1, replacement)).toBe(false);
+    });
+
+    it('given empty replacement and valid range, returns true', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph*', {
+        paragraph: paragraphType,
+      });
+
+      const child = new Node(paragraphType, {});
+      const node = new Node(nodeType, {}, Fragment.from([child]), []);
+
+      expect(node.canReplace(0, 1)).toBe(true);
+    });
+
+    it('given replacement with disallowed marks, returns false', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph', {
+        paragraph: paragraphType,
+      });
+      nodeType.markSet = [];
+
+      const child = new Node(paragraphType, {});
+      const node = new Node(nodeType, {}, Fragment.from([child]), []);
+      const markedNode = new Node(paragraphType, {}, undefined, [
+        createMark(boldMarkType, {}),
+      ]);
+      const replacement = Fragment.from([markedNode]);
+
+      expect(node.canReplace(0, 1, replacement)).toBe(false);
+    });
+  });
 });

--- a/packages/core/document/src/lib/entities/Node.ts
+++ b/packages/core/document/src/lib/entities/Node.ts
@@ -201,4 +201,24 @@ export class Node<TAttrs = Record<string, unknown>> {
   toString(): string {
     return this.type.name;
   }
+
+  canReplace(
+    from: number,
+    to: number,
+    replacement: Fragment<Node> = Fragment.empty<Node>(),
+    start = 0,
+    end = replacement.childCount
+  ): boolean {
+    const one = this.contentMatchAt(from).matchFragment(
+      replacement,
+      start,
+      end
+    );
+    const two = one && one.matchFragment(this.content, to);
+    if (!two || !two.validEnd) return false;
+    for (let i = start; i < end; i++) {
+      if (!this.type.allowsMarks(replacement.child(i).marks)) return false;
+    }
+    return true;
+  }
 }

--- a/packages/core/document/src/lib/entities/TextNode.spec.ts
+++ b/packages/core/document/src/lib/entities/TextNode.spec.ts
@@ -35,6 +35,12 @@ describe('TextNode', () => {
         'Node text cannot be empty'
       );
     });
+
+    it('given whitespace-only text, creates TextNode', () => {
+      const textNode = new TextNode(textType, {}, ' ');
+
+      expect(textNode.text).toBe(' ');
+    });
   });
 
   describe('nodeSize', () => {

--- a/packages/core/document/src/lib/entities/TextNode.ts
+++ b/packages/core/document/src/lib/entities/TextNode.ts
@@ -13,7 +13,7 @@ export class TextNode extends Node {
   ) {
     super(type, attrs, undefined, marks);
 
-    if ((typeof text === 'string' && text.trim() === '') || text === null) {
+    if (!text) {
       throw new RangeError('Node text cannot be empty');
     }
 

--- a/packages/core/document/src/lib/utils/replace.spec.ts
+++ b/packages/core/document/src/lib/utils/replace.spec.ts
@@ -1,0 +1,156 @@
+import { Fragment } from '../entities/Fragment';
+import { Node } from '../entities/Node';
+import { TextNode } from '../entities/TextNode';
+import { removeRange, insertInto } from './replace';
+import { createSelfRefNodeType, paragraphType, textType } from '../../testing';
+
+describe('removeRange', () => {
+  describe('given flat range at child boundary', () => {
+    it('removes the range and returns remaining fragment', () => {
+      const node1 = new Node(paragraphType, {});
+      const node2 = new Node(paragraphType, {});
+      const node3 = new Node(paragraphType, {});
+      const content = Fragment.from([node1, node2, node3]);
+
+      const result = removeRange(content, 2, 4);
+
+      expect(result.childCount).toBe(2);
+      expect(result.child(0)).toBe(node1);
+      expect(result.child(1)).toBe(node3);
+    });
+  });
+
+  describe('given range inside a text node', () => {
+    it('removes the text range and returns remaining fragment', () => {
+      const text = new TextNode(textType, {}, 'helloworld');
+      const content = Fragment.from([text]);
+
+      const result = removeRange(content, 2, 7);
+
+      expect((result.child(0) as TextNode).text).toBe('herld');
+    });
+  });
+
+  describe('given non-flat range crossing child boundaries', () => {
+    it('throws "Removing non-flat range"', () => {
+      const inner1 = new Node(
+        paragraphType,
+        {},
+        Fragment.from([new Node(paragraphType, {})]),
+        []
+      );
+      const inner2 = new Node(
+        paragraphType,
+        {},
+        Fragment.from([new Node(paragraphType, {})]),
+        []
+      );
+      const content = Fragment.from([inner1, inner2]);
+
+      expect(() => removeRange(content, 1, 5)).toThrow(
+        'Removing non-flat range'
+      );
+    });
+  });
+
+  describe('given range inside a single non-text child', () => {
+    it('removes recursively and returns updated fragment', () => {
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
+      const parent = new Node(
+        paragraphType,
+        {},
+        Fragment.from([child1, child2]),
+        []
+      );
+      const content = Fragment.from([parent]);
+
+      const result = removeRange(content, 1, 3);
+
+      expect(result.child(0).content.childCount).toBe(1);
+      expect(result.child(0).content.child(0)).toBe(child2);
+    });
+  });
+
+  describe('given null child at index', () => {
+    it('throws "Removing non-flat range"', () => {
+      const content = Fragment.empty<Node>();
+
+      expect(() => removeRange(content, 0, 0)).toThrow(
+        'Removing non-flat range'
+      );
+    });
+  });
+});
+
+describe('insertInto', () => {
+  describe('given dist at child boundary', () => {
+    it('inserts fragment at boundary and returns updated fragment', () => {
+      const node1 = new Node(paragraphType, {});
+      const node2 = new Node(paragraphType, {});
+      const inserted = new Node(paragraphType, {});
+      const content = Fragment.from([node1, node2]);
+
+      const result = insertInto(content, 2, Fragment.from([inserted]));
+
+      expect(result).not.toBeNull();
+      expect(result?.childCount).toBe(3);
+      expect(result?.child(1)).toBe(inserted);
+    });
+  });
+
+  describe('given dist inside a text node', () => {
+    it('inserts fragment and returns merged text', () => {
+      const text = new TextNode(textType, {}, 'helloworld');
+      const content = Fragment.from([text]);
+      const insert = Fragment.from([new TextNode(textType, {}, ' ')]);
+
+      const result = insertInto(content, 5, insert);
+
+      expect(result).not.toBeNull();
+      expect((result?.child(0) as TextNode).text).toBe('hello world');
+    });
+  });
+
+  describe('given parent that rejects the insert', () => {
+    it('returns null', () => {
+      const node1 = new Node(paragraphType, {});
+      const content = Fragment.from([node1]);
+      const insert = Fragment.from([new Node(paragraphType, {})]);
+      const rejectingParent = { canReplace: () => false } as unknown as Node;
+
+      const result = insertInto(content, 0, insert, rejectingParent);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('given dist inside a non-text child', () => {
+    it('inserts recursively and returns updated fragment', () => {
+      const childType = createSelfRefNodeType('child');
+      const child = new Node(childType, {});
+      const parent = new Node(childType, {}, Fragment.from([child]), []);
+      const content = Fragment.from([parent]);
+      const inserted = new Node(childType, {});
+
+      const result = insertInto(content, 1, Fragment.from([inserted]));
+
+      expect(result).not.toBeNull();
+      expect(result?.child(0).content.childCount).toBe(2);
+    });
+  });
+
+  describe('given null child at index', () => {
+    it('returns null', () => {
+      const content = Fragment.empty<Node>();
+
+      const result = insertInto(
+        content,
+        0,
+        Fragment.from([new Node(paragraphType, {})])
+      );
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/core/document/src/lib/utils/replace.ts
+++ b/packages/core/document/src/lib/utils/replace.ts
@@ -1,0 +1,48 @@
+import { Fragment } from '../entities/Fragment';
+import { Node } from '../entities/Node';
+
+export function removeRange(
+  content: Fragment<Node>,
+  from: number,
+  to: number
+): Fragment<Node> {
+  const { index, offset } = content.findIndex(from);
+  const child = content.maybeChild(index);
+  const { index: indexTo, offset: offsetTo } = content.findIndex(to);
+
+  if (child === null) throw new RangeError('Removing non-flat range');
+
+  if (offset === from || child.isText) {
+    if (offsetTo !== to && !content.child(indexTo).isText) {
+      throw new RangeError('Removing non-flat range');
+    }
+    return content.cut(0, from).append(content.cut(to));
+  }
+
+  if (index !== indexTo) throw new RangeError('Removing non-flat range');
+
+  return content.replaceChild(
+    index,
+    child.copy(removeRange(child.content, from - offset - 1, to - offset - 1))
+  );
+}
+
+export function insertInto(
+  content: Fragment<Node>,
+  dist: number,
+  insert: Fragment<Node>,
+  parent?: Node | null
+): Fragment<Node> | null {
+  const { index, offset } = content.findIndex(dist);
+  const child = content.maybeChild(index);
+
+  if (child === null) return null;
+
+  if (offset === dist || child.isText) {
+    if (parent && !parent.canReplace(index, index, insert)) return null;
+    return content.cut(0, dist).append(insert).append(content.cut(dist));
+  }
+
+  const inner = insertInto(child.content, dist - offset - 1, insert, child);
+  return inner && content.replaceChild(index, child.copy(inner));
+}

--- a/packages/core/document/src/lib/value-objects/Slice.spec.ts
+++ b/packages/core/document/src/lib/value-objects/Slice.spec.ts
@@ -1,6 +1,7 @@
 import { Fragment } from '../entities/Fragment';
 import { Node } from '../entities/Node';
 import { Slice } from './Slice';
+import { ContentMatch } from './ContentMatch';
 import {
   createMockNode,
   paragraphType,
@@ -8,8 +9,8 @@ import {
   emptyContent,
   nonEmptyContent,
   createMockNodeType,
+  createSelfRefNodeType,
 } from '../../testing';
-import { ContentMatch } from './ContentMatch';
 
 describe('Slice Value Object', () => {
   describe('constructor', () => {
@@ -183,6 +184,74 @@ describe('Slice Value Object', () => {
 
       expect(slice.openStart).toBe(0);
       expect(slice.openEnd).toBe(0);
+    });
+  });
+
+  describe('insertAt()', () => {
+    it('given valid pos and fragment, returns new Slice with fragment inserted', () => {
+      const node1 = new Node(paragraphType, {});
+      const node2 = new Node(paragraphType, {});
+      const inserted = new Node(paragraphType, {});
+      const slice = new Slice(Fragment.from([node1, node2]), 0, 0);
+
+      const result = slice.insertAt(2, Fragment.from([inserted]));
+
+      expect(result).not.toBeNull();
+      expect(result?.content.childCount).toBe(3);
+      expect(result?.content.child(1)).toBe(inserted);
+    });
+
+    it('given openStart offset, preserves openStart and openEnd on result', () => {
+      const innerType = createSelfRefNodeType('inner');
+      const inner1 = new Node(innerType, {});
+      const inner2 = new Node(innerType, {});
+      const outer = new Node(
+        innerType,
+        {},
+        Fragment.from([inner1, inner2]),
+        []
+      );
+      const slice = new Slice(Fragment.from([outer]), 1, 1);
+      const inserted = new Node(innerType, {});
+
+      const result = slice.insertAt(2, Fragment.from([inserted]));
+
+      expect(result).not.toBeNull();
+      expect(result?.openStart).toBe(1);
+      expect(result?.openEnd).toBe(1);
+    });
+  });
+
+  describe('removeBetween()', () => {
+    it('given valid range, returns new Slice with range removed', () => {
+      const node1 = new Node(paragraphType, {});
+      const node2 = new Node(paragraphType, {});
+      const node3 = new Node(paragraphType, {});
+      const slice = new Slice(Fragment.from([node1, node2, node3]), 0, 0);
+
+      const result = slice.removeBetween(2, 4);
+
+      expect(result.content.childCount).toBe(2);
+      expect(result.content.child(0)).toBe(node1);
+      expect(result.content.child(1)).toBe(node3);
+    });
+
+    it('given openStart offset, preserves openStart and openEnd on result', () => {
+      const innerType = createSelfRefNodeType('inner');
+      const inner1 = new Node(innerType, {});
+      const inner2 = new Node(innerType, {});
+      const outer = new Node(
+        innerType,
+        {},
+        Fragment.from([inner1, inner2]),
+        []
+      );
+      const slice = new Slice(Fragment.from([outer]), 1, 1);
+
+      const result = slice.removeBetween(0, 2);
+
+      expect(result.openStart).toBe(1);
+      expect(result.openEnd).toBe(1);
     });
   });
 });

--- a/packages/core/document/src/lib/value-objects/Slice.ts
+++ b/packages/core/document/src/lib/value-objects/Slice.ts
@@ -1,6 +1,6 @@
 import { Fragment } from '../entities/Fragment';
 import { Node } from '../entities/Node';
-
+import { insertInto, removeRange } from '../utils/replace';
 export class Slice {
   static readonly empty = new Slice(Fragment.empty<Node>(), 0, 0);
 
@@ -44,6 +44,19 @@ export class Slice {
 
   toString(): string {
     return `${this.content.toString()}(${this.openStart},${this.openEnd})`;
+  }
+
+  insertAt(pos: number, fragment: Fragment<Node>): Slice | null {
+    const content = insertInto(this.content, pos + this.openStart, fragment);
+    return content && new Slice(content, this.openStart, this.openEnd);
+  }
+
+  removeBetween(from: number, to: number): Slice {
+    return new Slice(
+      removeRange(this.content, from + this.openStart, to + this.openStart),
+      this.openStart,
+      this.openEnd
+    );
   }
 
   private static validateParameters(

--- a/packages/core/document/src/testing/index.ts
+++ b/packages/core/document/src/testing/index.ts
@@ -14,17 +14,51 @@ export const defaultNodeSpec: NodeSpec = { attrs: {} };
 export const defaultMarkSpec: MarkSpec = { attrs: {} };
 
 // — NodeType instances
-export const paragraphType = new NodeType('paragraph', defaultMockSchema, defaultNodeSpec);
-export const textType = new NodeType('text', defaultMockSchema, defaultNodeSpec);
-export const imageType = new NodeType('image', defaultMockSchema, defaultNodeSpec);
-export const headingType = new NodeType('heading', defaultMockSchema, defaultNodeSpec);
-export const spanType = new NodeType('span', defaultMockSchema, { attrs: {}, inline: true });
-export const mentionType = new NodeType('span', defaultMockSchema, { attrs: {}, atom: true });
+export const paragraphType = new NodeType(
+  'paragraph',
+  defaultMockSchema,
+  defaultNodeSpec
+);
+export const textType = new NodeType(
+  'text',
+  defaultMockSchema,
+  defaultNodeSpec
+);
+export const imageType = new NodeType(
+  'image',
+  defaultMockSchema,
+  defaultNodeSpec
+);
+export const headingType = new NodeType(
+  'heading',
+  defaultMockSchema,
+  defaultNodeSpec
+);
+export const spanType = new NodeType('span', defaultMockSchema, {
+  attrs: {},
+  inline: true,
+});
+export const mentionType = new NodeType('span', defaultMockSchema, {
+  attrs: {},
+  atom: true,
+});
 
 // — MarkType instances
-export const boldMarkType = new MarkType('bold', defaultMockSchema, defaultMarkSpec);
-export const italicMarkType = new MarkType('italic', defaultMockSchema, defaultMarkSpec);
-export const linkMarkType = new MarkType('link', defaultMockSchema, defaultMarkSpec);
+export const boldMarkType = new MarkType(
+  'bold',
+  defaultMockSchema,
+  defaultMarkSpec
+);
+export const italicMarkType = new MarkType(
+  'italic',
+  defaultMockSchema,
+  defaultMarkSpec
+);
+export const linkMarkType = new MarkType(
+  'link',
+  defaultMockSchema,
+  defaultMarkSpec
+);
 
 // — Shared Node setup
 export const mockChildNode = new Node(paragraphType, { attrs: {} });
@@ -43,7 +77,7 @@ export function createSchemaSpec(
 ): Record<string, NodeSpec> {
   return {
     doc: { content: 'paragraph+' },
-    text: {  },
+    text: {},
     paragraph: { attrs: {} },
     heading: { attrs: {} },
     ...extra,
@@ -96,7 +130,9 @@ export function createMockContentMatch(
   return new ContentMatch(validEnd, edges);
 }
 
-export function createMockNode(nameOrType: string | NodeType = 'paragraph'): Node {
+export function createMockNode(
+  nameOrType: string | NodeType = 'paragraph'
+): Node {
   const nodeType =
     typeof nameOrType === 'string'
       ? new NodeType(nameOrType, {}, { attrs: {} })
@@ -106,4 +142,10 @@ export function createMockNode(nameOrType: string | NodeType = 'paragraph'): Nod
 
 export function createMockFragment(nodes: Node[] = []): Fragment<Node> {
   return nodes.length === 0 ? Fragment.empty() : Fragment.from(nodes);
+}
+
+export function createSelfRefNodeType(name: string): NodeType {
+  const type = new NodeType(name, defaultMockSchema, {});
+  type.contentMatch = ContentMatch.parse(`${name}*`, { [name]: type });
+  return type;
 }


### PR DESCRIPTION
… fix, Node.canReplace

- Add utils/replace.ts with removeRange and insertInto helpers
- Add Slice.insertAt() and Slice.removeBetween() methods
- Add Node.canReplace() method
- Fix Fragment.cut() to handle text nodes correctly (from - pos, not from - pos - 1)
- Fix TextNode constructor to allow whitespace-only text
- Add createSelfRefNodeType factory to testing helpers

Issue #56