### PR TITLE
feat(document): implement Node.replace, Node.slice and replace algorithm

### DIFF
--- a/packages/core/document/src/index.ts
+++ b/packages/core/document/src/index.ts
@@ -19,6 +19,10 @@ export type {
 // Sevices
 export { Schema } from './lib/services/Schema';
 
+// Utils
+export { checkAttrs } from './lib/utils/attrs';
+export type { Attrs } from './lib/utils/attrs';
+
 // Value Objects
 export { Attribute } from './lib/value-objects/Attribute';
 export { ContentMatch } from './lib/value-objects/ContentMatch';

--- a/packages/core/document/src/lib/entities/Node.spec.ts
+++ b/packages/core/document/src/lib/entities/Node.spec.ts
@@ -3,6 +3,9 @@ import { NodeType } from '../value-objects/NodeType';
 import { Fragment } from './Fragment';
 import { ContentMatch } from '../value-objects/ContentMatch';
 import { ResolvedPos } from '../value-objects/ResolvedPos';
+import { TextNode } from './TextNode';
+import { Slice } from '../value-objects/Slice';
+import { ReplaceError } from '../errors/ReplaceError';
 import {
   defaultMockSchema,
   defaultNodeSpec,
@@ -489,6 +492,260 @@ describe('Node', () => {
       const replacement = Fragment.from([markedNode]);
 
       expect(node.canReplace(0, 1, replacement)).toBe(false);
+    });
+  });
+
+  describe('nodesBetween', () => {
+    it('given range covering all children, visits all nodes with startPos', () => {
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
+      const content = Fragment.from([child1, child2]);
+      const node = new Node(paragraphType, {}, content, []);
+
+      const visited: { node: Node; pos: number }[] = [];
+      node.nodesBetween(0, content.size, (n, pos) => {
+        visited.push({ node: n, pos });
+      });
+
+      expect(visited[0]).toEqual({ node: child1, pos: 0 });
+    });
+
+    it('given startPos provided, offsets visited node positions', () => {
+      const child1 = new Node(paragraphType, {});
+      const content = Fragment.from([child1]);
+      const node = new Node(paragraphType, {}, content, []);
+
+      const visited: number[] = [];
+      node.nodesBetween(
+        0,
+        content.size,
+        (n, pos) => {
+          visited.push(pos);
+        },
+        10
+      );
+
+      expect(visited[0]).toBe(10);
+    });
+  });
+
+  describe('rangeHasMark', () => {
+    it('given to equals from, returns false', () => {
+      const node = new Node(paragraphType, {}, Fragment.empty(), []);
+
+      expect(node.rangeHasMark(1, 1, boldMarkType)).toBe(false);
+    });
+
+    it('given mark present in range, returns true', () => {
+      const mark = createMark(boldMarkType, {});
+      const text = new TextNode(textType, {}, 'hello', [mark]);
+      const node = new Node(paragraphType, {}, Fragment.from([text]), []);
+
+      expect(node.rangeHasMark(0, text.nodeSize, boldMarkType)).toBe(true);
+    });
+
+    it('given mark not present in range, returns false', () => {
+      const text = new TextNode(textType, {}, 'hello', []);
+      const node = new Node(paragraphType, {}, Fragment.from([text]), []);
+
+      expect(node.rangeHasMark(0, text.nodeSize, boldMarkType)).toBe(false);
+    });
+  });
+
+  describe('canReplaceWith', () => {
+    it('given type matching content, returns true', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph', {
+        paragraph: paragraphType,
+      });
+
+      const child = new Node(paragraphType, {});
+      const node = new Node(nodeType, {}, Fragment.from([child]), []);
+
+      expect(node.canReplaceWith(0, 1, paragraphType)).toBe(true);
+    });
+
+    it('given type not matching content, returns false', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph', {
+        paragraph: paragraphType,
+      });
+
+      const child = new Node(paragraphType, {});
+      const node = new Node(nodeType, {}, Fragment.from([child]), []);
+
+      expect(node.canReplaceWith(0, 1, headingType)).toBe(false);
+    });
+
+    it('given marks not allowed by node type, returns false', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph', {
+        paragraph: paragraphType,
+      });
+      nodeType.markSet = [];
+
+      const child = new Node(paragraphType, {});
+      const node = new Node(nodeType, {}, Fragment.from([child]), []);
+
+      expect(
+        node.canReplaceWith(0, 1, paragraphType, [createMark(boldMarkType, {})])
+      ).toBe(false);
+    });
+  });
+
+  describe('canAppend', () => {
+    it('given other with compatible non-empty content, returns true', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph*', {
+        paragraph: paragraphType,
+      });
+
+      const child = new Node(paragraphType, {});
+      const node = new Node(nodeType, {}, Fragment.from([child]), []);
+      const other = new Node(
+        nodeType,
+        {},
+        Fragment.from([new Node(paragraphType, {})]),
+        []
+      );
+
+      expect(node.canAppend(other)).toBe(true);
+    });
+
+    it('given other content not allowed by content model, returns false', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph*', {
+        paragraph: paragraphType,
+      });
+
+      const node = new Node(nodeType, {}, Fragment.empty(), []);
+      const other = new Node(nodeType, {}, Fragment.empty(), []);
+
+      expect(node.canAppend(other)).toBe(true);
+    });
+  });
+
+  describe('check', () => {
+    it('given valid node, does not throw', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.empty;
+
+      const node = new Node(nodeType, {}, Fragment.empty(), []);
+
+      expect(() => node.check()).not.toThrow();
+    });
+
+    it('given node with invalid content, throws RangeError', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph', {
+        paragraph: paragraphType,
+      });
+
+      const node = new Node(
+        nodeType,
+        {},
+        Fragment.from([new Node(headingType, {})]),
+        []
+      );
+
+      expect(() => node.check()).toThrow(RangeError);
+    });
+
+    it('given node with invalid mark set order, throws RangeError', () => {
+      const mark1 = createMark(boldMarkType, {});
+      const mark2 = createMark(italicMarkType, {});
+      boldMarkType.rank = 2;
+      italicMarkType.rank = 1;
+
+      const node = new Node(paragraphType, {}, Fragment.empty(), [
+        mark1,
+        mark2,
+      ]);
+
+      expect(() => node.check()).toThrow(RangeError);
+    });
+  });
+
+  describe('resolve', () => {
+    it('given valid pos, returns ResolvedPos', () => {
+      const child = new Node(paragraphType, {});
+      const node = new Node(paragraphType, {}, Fragment.from([child]), []);
+
+      expect(node.resolve(1)).toBeInstanceOf(ResolvedPos);
+    });
+  });
+
+  describe('replace', () => {
+    it('given valid slice, returns new node with replaced content', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph*', {
+        paragraph: paragraphType,
+      });
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
+      const root = new Node(nodeType, {}, Fragment.from([child1, child2]), []);
+      const inserted = new Node(paragraphType, {});
+      const slice = new Slice(Fragment.from([inserted]), 0, 0);
+
+      const result = root.replace(0, child1.nodeSize, slice);
+
+      expect(result.childCount).toBe(2);
+    });
+
+    it('given invalid slice, throws ReplaceError', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph*', {
+        paragraph: paragraphType,
+      });
+      const child = new Node(paragraphType, {});
+      const root = new Node(nodeType, {}, Fragment.from([child]), []);
+      const slice = new Slice(Fragment.from([child]), 2, 2);
+
+      expect(() => root.replace(0, child.nodeSize, slice)).toThrow(
+        ReplaceError
+      );
+    });
+  });
+
+  describe('slice', () => {
+    it('given from equals to, returns Slice.empty', () => {
+      const child = new Node(paragraphType, {});
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph*', {
+        paragraph: paragraphType,
+      });
+      const root = new Node(nodeType, {}, Fragment.from([child]), []);
+
+      expect(root.slice(0, 0)).toBe(Slice.empty);
+    });
+
+    it('given valid range, returns slice with correct content', () => {
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph*', {
+        paragraph: paragraphType,
+      });
+      const root = new Node(nodeType, {}, Fragment.from([child1, child2]), []);
+
+      const result = root.slice(0, child1.nodeSize);
+
+      expect(result).toBeInstanceOf(Slice);
+      expect(result.content.childCount).toBe(1);
+    });
+
+    it('given includeParents true, returns slice with depth 0', () => {
+      const child = new Node(paragraphType, {});
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph*', {
+        paragraph: paragraphType,
+      });
+      const root = new Node(nodeType, {}, Fragment.from([child]), []);
+
+      const result = root.slice(0, child.nodeSize, true);
+
+      expect(result.openStart).toBe(0);
+      expect(result.openEnd).toBe(0);
     });
   });
 });

--- a/packages/core/document/src/lib/entities/Node.ts
+++ b/packages/core/document/src/lib/entities/Node.ts
@@ -1,8 +1,12 @@
+import { Attrs } from '../utils/attrs';
 import { deepEqual } from '../utils/deep-equal';
+import { replace } from '../utils/replace';
 import { ContentMatch } from '../value-objects/ContentMatch';
 import { Mark } from '../value-objects/Mark';
+import { MarkType } from '../value-objects/MarkType';
 import { NodeType } from '../value-objects/NodeType';
 import { ResolvedPos } from '../value-objects/ResolvedPos';
+import { Slice } from '../value-objects/Slice';
 import { Fragment } from './Fragment';
 
 export class Node<TAttrs = Record<string, unknown>> {
@@ -220,5 +224,91 @@ export class Node<TAttrs = Record<string, unknown>> {
       if (!this.type.allowsMarks(replacement.child(i).marks)) return false;
     }
     return true;
+  }
+
+  nodesBetween(
+    from: number,
+    to: number,
+    callback: (
+      node: Node,
+      pos: number,
+      parent: Node | null,
+      index: number
+    ) => void | boolean,
+    startPos = 0
+  ): void {
+    this.content.nodesBetween(from, to, callback, startPos, this as Node);
+  }
+
+  rangeHasMark(from: number, to: number, type: Mark | MarkType): boolean {
+    let found = false;
+    if (to > from) {
+      this.nodesBetween(from, to, (node) => {
+        if (type.isInSet(node.marks)) found = true;
+        return !found;
+      });
+    }
+    return found;
+  }
+
+  canReplaceWith(
+    from: number,
+    to: number,
+    type: NodeType,
+    marks?: readonly Mark[]
+  ): boolean {
+    if (marks && !this.type.allowsMarks(marks)) return false;
+    const start = this.contentMatchAt(from).matchType(type);
+    const end = start && start.matchFragment(this.content, to);
+    return end ? end.validEnd : false;
+  }
+
+  canAppend(other: Node): boolean {
+    if (other.content.size) {
+      return this.canReplace(this.childCount, this.childCount, other.content);
+    }
+    return this.type.compatibleContent(other.type);
+  }
+
+  check(): void {
+    this.type.checkContent(this.content);
+    this.type.checkAttrs(this.attrs as Attrs);
+    let copy: readonly Mark[] = Mark.none;
+    for (let i = 0; i < this.marks.length; i++) {
+      const mark = this.marks[i];
+      mark.type.checkAttrs(mark.attrs);
+      copy = mark.addToSet(copy);
+    }
+    if (!Mark.sameSet(copy, this.marks)) {
+      throw new RangeError(
+        `Invalid collection of marks for node ${
+          this.type.name
+        }: ${this.marks.map((m) => m.type.name)}`
+      );
+    }
+    this.content.forEach((node) => node.check());
+  }
+
+  resolve(pos: number): ResolvedPos {
+    return this.resolveNoCache(pos);
+  }
+
+  replace(from: number, to: number, slice: Slice): Node {
+    return replace(this.resolve(from), this.resolve(to), slice);
+  }
+
+  slice(
+    from: number,
+    to: number = this.content.size,
+    includeParents = false
+  ): Slice {
+    if (from === to) return Slice.empty;
+    const $from = this.resolve(from);
+    const $to = this.resolve(to);
+    const depth = includeParents ? 0 : $from.sharedDepth(to);
+    const start = $from.start(depth);
+    const node = $from.node(depth);
+    const content = node.content.cut($from.pos - start, $to.pos - start);
+    return new Slice(content, $from.depth - depth, $to.depth - depth);
   }
 }

--- a/packages/core/document/src/lib/utils/attrs.ts
+++ b/packages/core/document/src/lib/utils/attrs.ts
@@ -1,0 +1,25 @@
+import { Attribute } from '../value-objects/Attribute';
+
+export type Attrs = Record<string, unknown>;
+
+export function checkAttrs(
+  attrs: Record<string, Attribute>,
+  values: Attrs,
+  type: string,
+  name: string
+): void {
+  for (const key in values) {
+    if (!(key in attrs)) {
+      throw new RangeError(
+        `Unsupported attribute ${key} for ${type} of type ${name}`
+      );
+    }
+  }
+
+  for (const key in attrs) {
+    const attr = attrs[key];
+    if (attr.spec.validate) {
+      attr.spec.validate(values[key]);
+    }
+  }
+}

--- a/packages/core/document/src/lib/utils/replace.spec.ts
+++ b/packages/core/document/src/lib/utils/replace.spec.ts
@@ -1,8 +1,35 @@
 import { Fragment } from '../entities/Fragment';
 import { Node } from '../entities/Node';
 import { TextNode } from '../entities/TextNode';
-import { removeRange, insertInto } from './replace';
-import { createSelfRefNodeType, paragraphType, textType } from '../../testing';
+import { ReplaceError } from '../errors/ReplaceError';
+import { ResolvedPos } from '../value-objects/ResolvedPos';
+import { NodeType } from '../value-objects/NodeType';
+import { ContentMatch } from '../value-objects/ContentMatch';
+import { Slice } from '../value-objects/Slice';
+import {
+  removeRange,
+  insertInto,
+  addNode,
+  checkJoin,
+  joinable,
+  close,
+  addRange,
+  replaceTwoWay,
+  replaceThreeWay,
+  prepareSliceForReplace,
+  replaceOuter,
+  replace,
+} from './replace';
+import {
+  boldMarkType,
+  createMark,
+  createSelfRefNodeType,
+  defaultMockSchema,
+  defaultNodeSpec,
+  headingType,
+  paragraphType,
+  textType,
+} from '../../testing';
 
 describe('removeRange', () => {
   describe('given flat range at child boundary', () => {
@@ -151,6 +178,291 @@ describe('insertInto', () => {
       );
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('addNode', () => {
+    it('given non-text node, pushes to target', () => {
+      const target: Node[] = [];
+      const node = new Node(paragraphType, {});
+
+      addNode(node, target);
+
+      expect(target).toHaveLength(1);
+    });
+
+    it('given text node with same markup as last, merges into last', () => {
+      const text1 = new TextNode(textType, {}, 'hello');
+      const text2 = new TextNode(textType, {}, ' world');
+      const target: Node[] = [text1];
+
+      addNode(text2, target);
+
+      expect(target).toHaveLength(1);
+      expect((target[0] as TextNode).text).toBe('hello world');
+    });
+
+    it('given text node with different markup, pushes to target', () => {
+      const mark = createMark(boldMarkType, {});
+      const text1 = new TextNode(textType, {}, 'hello');
+      const text2 = new TextNode(textType, {}, ' world', [mark]);
+      const target: Node[] = [text1];
+
+      addNode(text2, target);
+
+      expect(target).toHaveLength(2);
+    });
+  });
+  describe('checkJoin', () => {
+    it('given compatible nodes, does not throw', () => {
+      const node1 = new Node(paragraphType, {});
+      const node2 = new Node(paragraphType, {});
+
+      expect(() => checkJoin(node1, node2)).not.toThrow();
+    });
+
+    it('given incompatible nodes, throws ReplaceError', () => {
+      const node1 = new Node(paragraphType, {});
+      const node2 = new Node(headingType, {});
+
+      expect(() => checkJoin(node1, node2)).toThrow(ReplaceError);
+    });
+  });
+
+  describe('joinable', () => {
+    it('given compatible nodes at depth, returns node', () => {
+      const child = new Node(paragraphType, {});
+      const root = new Node(paragraphType, {}, Fragment.from([child]), []);
+      const $before = ResolvedPos.resolve(root, 1);
+      const $after = ResolvedPos.resolve(root, 1);
+
+      expect(joinable($before, $after, 0)).toBe(root);
+    });
+
+    it('given incompatible nodes at depth, throws ReplaceError', () => {
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(headingType, {});
+      const root1 = new Node(paragraphType, {}, Fragment.from([child1]), []);
+      const root2 = new Node(headingType, {}, Fragment.from([child2]), []);
+      const $before = ResolvedPos.resolve(root1, 0);
+      const $after = ResolvedPos.resolve(root2, 0);
+
+      expect(() => joinable($before, $after, 0)).toThrow(ReplaceError);
+    });
+  });
+
+  describe('close', () => {
+    it('given valid content, returns node copy with content', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph', {
+        paragraph: paragraphType,
+      });
+
+      const child = new Node(paragraphType, {});
+      const content = Fragment.from([child]);
+      const node = new Node(nodeType, {}, Fragment.empty(), []);
+
+      const result = close(node, content);
+
+      expect(result.content).toBe(content);
+    });
+
+    it('given invalid content, throws RangeError', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph', {
+        paragraph: paragraphType,
+      });
+
+      const node = new Node(nodeType, {}, Fragment.empty(), []);
+
+      expect(() =>
+        close(node, Fragment.from([new Node(headingType, {})]))
+      ).toThrow(RangeError);
+    });
+  });
+
+  describe('addRange', () => {
+    it('given null start and null end, does nothing', () => {
+      const target: Node[] = [];
+
+      addRange(null, null, 0, target);
+
+      expect(target).toHaveLength(0);
+    });
+
+    it('given start and end at same depth, adds nodes between', () => {
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
+      const root = new Node(
+        paragraphType,
+        {},
+        Fragment.from([child1, child2]),
+        []
+      );
+      const $start = ResolvedPos.resolve(root, 0);
+      const $end = ResolvedPos.resolve(root, root.content.size);
+      const target: Node[] = [];
+
+      addRange($start, $end, 0, target);
+
+      expect(target).toHaveLength(2);
+    });
+  });
+
+  describe('replaceTwoWay', () => {
+    it('given from and to in middle, returns surrounding nodes', () => {
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
+      const child3 = new Node(paragraphType, {});
+      const root = new Node(
+        paragraphType,
+        {},
+        Fragment.from([child1, child2, child3]),
+        []
+      );
+      const $from = ResolvedPos.resolve(root, child1.nodeSize);
+      const $to = ResolvedPos.resolve(root, child1.nodeSize + child2.nodeSize);
+
+      const result = replaceTwoWay($from, $to, 0);
+
+      expect(result.childCount).toBe(2);
+    });
+  });
+
+  describe('replaceThreeWay', () => {
+    it('given flat range with slice content, returns merged fragment', () => {
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
+      const child3 = new Node(paragraphType, {});
+      const root = new Node(
+        paragraphType,
+        {},
+        Fragment.from([child1, child2, child3]),
+        []
+      );
+      const $from = ResolvedPos.resolve(root, 0);
+      const $to = ResolvedPos.resolve(root, root.content.size);
+      const $start = ResolvedPos.resolve(root, 0);
+      const $end = ResolvedPos.resolve(root, root.content.size);
+
+      const result = replaceThreeWay($from, $start, $end, $to, 0);
+
+      expect(result.childCount).toBe(3);
+    });
+  });
+
+  describe('prepareSliceForReplace', () => {
+    it('given slice with openStart 0, returns start and end resolved positions', () => {
+      const child = new Node(paragraphType, {});
+      const root = new Node(paragraphType, {}, Fragment.from([child]), []);
+      const $along = ResolvedPos.resolve(root, 0);
+      const slice = new Slice(Fragment.from([child]), 0, 0);
+
+      const result = prepareSliceForReplace(slice, $along);
+
+      expect(result.start).toBeInstanceOf(ResolvedPos);
+      expect(result.end).toBeInstanceOf(ResolvedPos);
+    });
+  });
+
+  describe('replaceOuter', () => {
+    it('given empty slice, returns node with replaceTwoWay content', () => {
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph*', {
+        paragraph: paragraphType,
+      });
+      const root = new Node(nodeType, {}, Fragment.from([child1, child2]), []);
+      const $from = ResolvedPos.resolve(root, child1.nodeSize);
+      const $to = ResolvedPos.resolve(root, child1.nodeSize);
+
+      const result = replaceOuter($from, $to, Slice.empty, 0);
+
+      expect(result.childCount).toBe(2);
+    });
+
+    it('given flat slice, returns node with slice content inserted', () => {
+      const child1 = new Node(paragraphType, {});
+      const child2 = new Node(paragraphType, {});
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph*', {
+        paragraph: paragraphType,
+      });
+      const root = new Node(nodeType, {}, Fragment.from([child1, child2]), []);
+      const $from = ResolvedPos.resolve(root, 0);
+      const $to = ResolvedPos.resolve(root, child1.nodeSize);
+      const inserted = new Node(paragraphType, {});
+      const slice = new Slice(Fragment.from([inserted]), 0, 0);
+
+      const result = replaceOuter($from, $to, slice, 0);
+
+      expect(result.childCount).toBe(2);
+    });
+
+    it('given slice with openStart, uses replaceThreeWay', () => {
+      const innerType = createSelfRefNodeType('inner');
+      const inner1 = new Node(innerType, {});
+      const inner2 = new Node(innerType, {});
+      const outer = new Node(
+        innerType,
+        {},
+        Fragment.from([inner1, inner2]),
+        []
+      );
+      const root = new Node(innerType, {}, Fragment.from([outer]), []);
+      const $from = ResolvedPos.resolve(root, 1);
+      const $to = ResolvedPos.resolve(root, root.content.size - 1);
+      const slice = new Slice(Fragment.from([new Node(innerType, {})]), 1, 1);
+
+      const result = replaceOuter($from, $to, slice, 0);
+
+      expect(result).toBeInstanceOf(Node);
+    });
+  });
+
+  describe('replace', () => {
+    it('given valid slice, returns replaced node', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph*', {
+        paragraph: paragraphType,
+      });
+      const child = new Node(paragraphType, {});
+      const root = new Node(nodeType, {}, Fragment.from([child]), []);
+      const $from = ResolvedPos.resolve(root, 0);
+      const $to = ResolvedPos.resolve(root, child.nodeSize);
+
+      const result = replace($from, $to, Slice.empty);
+
+      expect(result).toBeInstanceOf(Node);
+    });
+
+    it('given slice openStart deeper than from depth, throws ReplaceError', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph*', {
+        paragraph: paragraphType,
+      });
+      const child = new Node(paragraphType, {});
+      const root = new Node(nodeType, {}, Fragment.from([child]), []);
+      const $from = ResolvedPos.resolve(root, 0);
+      const $to = ResolvedPos.resolve(root, child.nodeSize);
+      const slice = new Slice(Fragment.from([child]), 2, 2);
+
+      expect(() => replace($from, $to, slice)).toThrow(ReplaceError);
+    });
+
+    it('given inconsistent open depths, throws ReplaceError', () => {
+      const nodeType = new NodeType('doc', defaultMockSchema, defaultNodeSpec);
+      nodeType.contentMatch = ContentMatch.parse('paragraph*', {
+        paragraph: paragraphType,
+      });
+      const child = new Node(paragraphType, {});
+      const root = new Node(nodeType, {}, Fragment.from([child]), []);
+      const $from = ResolvedPos.resolve(root, 0);
+      const $to = ResolvedPos.resolve(root, child.nodeSize);
+      const slice = new Slice(Fragment.from([child]), 0, 1);
+
+      expect(() => replace($from, $to, slice)).toThrow(ReplaceError);
     });
   });
 });

--- a/packages/core/document/src/lib/utils/replace.ts
+++ b/packages/core/document/src/lib/utils/replace.ts
@@ -1,5 +1,9 @@
 import { Fragment } from '../entities/Fragment';
 import { Node } from '../entities/Node';
+import { TextNode } from '../entities/TextNode';
+import { ReplaceError } from '../errors/ReplaceError';
+import { ResolvedPos } from '../value-objects/ResolvedPos';
+import { Slice } from '../value-objects/Slice';
 
 export function removeRange(
   content: Fragment<Node>,
@@ -45,4 +49,181 @@ export function insertInto(
 
   const inner = insertInto(child.content, dist - offset - 1, insert, child);
   return inner && content.replaceChild(index, child.copy(inner));
+}
+
+export function addNode(child: Node, target: Node[]): void {
+  const last = target.length - 1;
+  if (last >= 0 && child.isText && child.sameMarkup(target[last])) {
+    target[last] = (child as TextNode).withText(
+      (target[last] as TextNode).text + (child as TextNode).text
+    );
+  } else {
+    target.push(child);
+  }
+}
+
+export function checkJoin(main: Node, sub: Node): void {
+  if (!sub.type.compatibleContent(main.type)) {
+    throw new ReplaceError(
+      `Cannot join ${sub.type.name} onto ${main.type.name}`
+    );
+  }
+}
+
+export function joinable(
+  $before: ResolvedPos,
+  $after: ResolvedPos,
+  depth: number
+): Node {
+  const node = $before.node(depth);
+  checkJoin(node, $after.node(depth));
+  return node;
+}
+
+export function close(node: Node, content: Fragment<Node>): Node {
+  node.type.checkContent(content);
+  return node.copy(content);
+}
+
+export function addRange(
+  $start: ResolvedPos | null,
+  $end: ResolvedPos | null,
+  depth: number,
+  target: Node[]
+): void {
+  const resolvedNode = $end ?? $start;
+  if (!resolvedNode) return;
+  const node = resolvedNode.node(depth);
+  let startIndex = 0;
+  const endIndex = $end ? $end.index(depth) : node.childCount;
+
+  if ($start) {
+    startIndex = $start.index(depth);
+    if ($start.depth > depth) {
+      startIndex++;
+    } else if ($start.textOffset) {
+      if ($start.nodeAfter) addNode($start.nodeAfter, target);
+      startIndex++;
+    }
+  }
+
+  for (let i = startIndex; i < endIndex; i++) {
+    addNode(node.child(i), target);
+  }
+
+  if ($end && $end.depth === depth && $end.textOffset) {
+    if ($end.nodeBefore) addNode($end.nodeBefore, target);
+  }
+}
+
+export function replaceTwoWay(
+  $from: ResolvedPos,
+  $to: ResolvedPos,
+  depth: number
+): Fragment<Node> {
+  const content: Node[] = [];
+  addRange(null, $from, depth, content);
+  if ($from.depth > depth) {
+    const type = joinable($from, $to, depth + 1);
+    addNode(close(type, replaceTwoWay($from, $to, depth + 1)), content);
+  }
+  addRange($to, null, depth, content);
+  return Fragment.from(content);
+}
+
+export function replaceThreeWay(
+  $from: ResolvedPos,
+  $start: ResolvedPos,
+  $end: ResolvedPos,
+  $to: ResolvedPos,
+  depth: number
+): Fragment<Node> {
+  const openStart = $from.depth > depth && joinable($from, $start, depth + 1);
+  const openEnd = $to.depth > depth && joinable($end, $to, depth + 1);
+  const content: Node[] = [];
+
+  addRange(null, $from, depth, content);
+
+  if (openStart && openEnd && $start.index(depth) === $end.index(depth)) {
+    checkJoin(openStart, openEnd);
+    addNode(
+      close(openStart, replaceThreeWay($from, $start, $end, $to, depth + 1)),
+      content
+    );
+  } else {
+    if (openStart)
+      addNode(
+        close(openStart, replaceTwoWay($from, $start, depth + 1)),
+        content
+      );
+    addRange($start, $end, depth, content);
+    if (openEnd)
+      addNode(close(openEnd, replaceTwoWay($end, $to, depth + 1)), content);
+  }
+
+  addRange($to, null, depth, content);
+  return Fragment.from(content);
+}
+
+export function prepareSliceForReplace(
+  slice: Slice,
+  $along: ResolvedPos
+): { start: ResolvedPos; end: ResolvedPos } {
+  const extra = $along.depth - slice.openStart;
+  const parent = $along.node(extra);
+  let node = parent.copy(slice.content);
+  for (let i = extra - 1; i >= 0; i--) {
+    node = $along.node(i).copy(Fragment.from([node]));
+  }
+  return {
+    start: node.resolveNoCache(slice.openStart + extra),
+    end: node.resolveNoCache(node.content.size - slice.openEnd - extra),
+  };
+}
+
+export function replaceOuter(
+  $from: ResolvedPos,
+  $to: ResolvedPos,
+  slice: Slice,
+  depth: number
+): Node {
+  const index = $from.index(depth);
+  const node = $from.node(depth);
+
+  if (index === $to.index(depth) && depth < $from.depth - slice.openStart) {
+    const inner = replaceOuter($from, $to, slice, depth + 1);
+    return node.copy(node.content.replaceChild(index, inner));
+  } else if (!slice.content.size) {
+    return close(node, replaceTwoWay($from, $to, depth));
+  } else if (
+    !slice.openStart &&
+    !slice.openEnd &&
+    $from.depth === depth &&
+    $to.depth === depth
+  ) {
+    const parent = $from.parent;
+    const content = parent.content;
+    return close(
+      parent,
+      content
+        .cut(0, $from.parentOffset)
+        .append(slice.content)
+        .append(content.cut($to.parentOffset))
+    );
+  } else {
+    const { start, end } = prepareSliceForReplace(slice, $from);
+    return close(node, replaceThreeWay($from, start, end, $to, depth));
+  }
+}
+
+export function replace(
+  $from: ResolvedPos,
+  $to: ResolvedPos,
+  slice: Slice
+): Node {
+  if (slice.openStart > $from.depth)
+    throw new ReplaceError('Inserted content deeper than insertion position');
+  if ($from.depth - slice.openStart !== $to.depth - slice.openEnd)
+    throw new ReplaceError('Inconsistent open depths');
+  return replaceOuter($from, $to, slice, 0);
 }

--- a/packages/core/document/src/lib/value-objects/MarkType.spec.ts
+++ b/packages/core/document/src/lib/value-objects/MarkType.spec.ts
@@ -155,4 +155,38 @@ describe('MarkType', () => {
       expect(boldMarkType.removeFromSet(set)).toBe(set);
     });
   });
+
+  describe('checkAttrs', () => {
+    it('given attrs with no extra keys, returns void', () => {
+      const markType = createMarkType('strong', defaultMockSchema, {
+        attrs: { color: { default: 'black' } },
+      });
+      expect(() => markType.checkAttrs({ color: 'red' })).not.toThrow();
+    });
+
+    it('given unsupported attr key, throws RangeError', () => {
+      const markType = createMarkType('strong', defaultMockSchema, {
+        attrs: { color: { default: 'black' } },
+      });
+      expect(() => markType.checkAttrs({ color: 'red', unknown: 'x' })).toThrow(
+        RangeError
+      );
+    });
+
+    it('given attr with validate fn that throws, propagates the error', () => {
+      const markType = createMarkType('strong', defaultMockSchema, {
+        attrs: {
+          color: {
+            default: 'black',
+            validate: (v: unknown) => {
+              if (typeof v !== 'string')
+                throw new RangeError('color must be string');
+            },
+          },
+        },
+      });
+
+      expect(() => markType.checkAttrs({ color: 42 })).toThrow(RangeError);
+    });
+  });
 });

--- a/packages/core/document/src/lib/value-objects/MarkType.ts
+++ b/packages/core/document/src/lib/value-objects/MarkType.ts
@@ -1,10 +1,13 @@
 import { MarkSpec } from '../interfaces/SchemaSpec';
+import { Attrs, checkAttrs } from '../utils/attrs';
+import { Attribute } from './Attribute';
 import { Mark } from './Mark';
 
 export class MarkType {
   readonly name: string;
   readonly schema: unknown;
   readonly spec: MarkSpec;
+  readonly attrs: Record<string, Attribute>;
   excluded: readonly MarkType[] = [];
   rank = 0;
 
@@ -16,6 +19,13 @@ export class MarkType {
     this.name = name;
     this.schema = schema;
     this.spec = spec;
+    this.attrs = {};
+
+    if (spec.attrs) {
+      for (const [attrName, attrSpec] of Object.entries(spec.attrs)) {
+        this.attrs[attrName] = new Attribute(attrSpec as never);
+      }
+    }
   }
 
   create(attrs?: Record<string, unknown>): Mark {
@@ -43,9 +53,13 @@ export class MarkType {
 
     return this.name === other.name;
   }
-  
+
   excludes(other: MarkType): boolean {
     return this.excluded.indexOf(other) > -1;
+  }
+
+  checkAttrs(attrs: Attrs): void {
+    checkAttrs(this.attrs, attrs, 'mark', this.name);
   }
 
   private validateParameter(paramName: string, paramValue: unknown): void {

--- a/packages/core/document/src/lib/value-objects/NodeType.spec.ts
+++ b/packages/core/document/src/lib/value-objects/NodeType.spec.ts
@@ -664,4 +664,48 @@ describe('NodeType', () => {
       expect(nodeType.whitespace).toBe('pre');
     });
   });
+
+  describe('checkAttrs', () => {
+    it('given attrs with no extra keys, returns void', () => {
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec({ attrs: { level: { default: 1 } } })
+      );
+
+      expect(() => nodeType.checkAttrs({ level: 1 })).not.toThrow();
+    });
+
+    it('given unsupported attr key, throws RangeError', () => {
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec({ attrs: { level: { default: 1 } } })
+      );
+
+      expect(() => nodeType.checkAttrs({ level: 1, unknown: 'x' })).toThrow(
+        RangeError
+      );
+    });
+
+    it('given attr with validate fn that throws, propagates the error', () => {
+      const nodeType = createMockNodeType(
+        'paragraph',
+        defaultMockSchema,
+        createNodeSpec({
+          attrs: {
+            level: {
+              default: 1,
+              validate: (v: unknown) => {
+                if (typeof v !== 'number')
+                  throw new RangeError('level must be number');
+              },
+            },
+          },
+        })
+      );
+
+      expect(() => nodeType.checkAttrs({ level: 'bad' })).toThrow(RangeError);
+    });
+  });
 });

--- a/packages/core/document/src/lib/value-objects/NodeType.ts
+++ b/packages/core/document/src/lib/value-objects/NodeType.ts
@@ -1,6 +1,7 @@
 import { Fragment } from '../entities/Fragment';
 import { Node } from '../entities/Node';
 import { NodeSpec } from '../interfaces/SchemaSpec';
+import { Attrs, checkAttrs } from '../utils/attrs';
 import { Attribute } from './Attribute';
 import { ContentMatch } from './ContentMatch';
 import { Mark } from './Mark';
@@ -45,7 +46,7 @@ export class NodeType {
     return this.markSet === null || this.markSet.indexOf(markType) > -1;
   }
 
-  allowsMarks(marks: Mark[]): boolean {
+  allowsMarks(marks: readonly Mark[]): boolean {
     if (this.markSet === null) return true;
     return marks.every(
       (mark) => this.markSet && this.markSet.indexOf(mark.type) > -1
@@ -108,6 +109,10 @@ export class NodeType {
     return new Node(this, attrs || {}, nodes, marks || []);
   }
 
+  checkAttrs(attrs: Attrs): void {
+    checkAttrs(this.attrs, attrs, 'node', this.name);
+  }
+
   createAndFill(
     attrs?: Record<string, unknown>,
     content?: Fragment<Node> | Node[],
@@ -159,20 +164,29 @@ export class NodeType {
     if (!result || !result.validEnd) return false;
 
     for (let i = 0; i < content.childCount; i++) {
-      if (!this.allowsMarks(content.child(i).marks)) return false
+      if (!this.allowsMarks(content.child(i).marks)) return false;
     }
 
     return true;
   }
 
-  createChecked(attrs?: Record<string, unknown>, content?: Fragment<Node> | Node[], marks?: Mark[]): Node {
+  createChecked(
+    attrs?: Record<string, unknown>,
+    content?: Fragment<Node> | Node[],
+    marks?: Mark[]
+  ): Node {
     const node = this.create(attrs, content, marks);
     this.checkContent(node.content);
     return node;
   }
 
   compatibleContent(other: NodeType): boolean {
-    return this === other || this.contentMatch?.compatible(other.contentMatch ?? ContentMatch.empty) === true;
+    return (
+      this === other ||
+      this.contentMatch?.compatible(
+        other.contentMatch ?? ContentMatch.empty
+      ) === true
+    );
   }
 
   checkContent(content: Fragment<Node>): void {


### PR DESCRIPTION
- Add Attrs type to SchemaSpec
- Add checkAttrs to NodeType and MarkType
- Add attrs field to MarkType
- Add checkAttrs free function to utils/attrs.ts
- Add Node.nodesBetween wrapper
- Add Node.rangeHasMark
- Add Node.canReplaceWith
- Add Node.canAppend
- Add Node.check
- Add Node.resolve
- Add replace algorithm helpers to utils/replace.ts
- Add Node.replace
- Add Node.slice

Issue #57