### PR TITLE
feat(document): implement ResolvedPos marks, marksAcross, posAtIndex,…

### DIFF
--- a/packages/core/document/src/lib/contracts/IMarkType.ts
+++ b/packages/core/document/src/lib/contracts/IMarkType.ts
@@ -2,7 +2,8 @@ import type { IMark } from './IMark';
 
 export interface IMarkType {
   readonly name: string;
-  readonly rank: number;
+  rank: number;
+  inclusive?: boolean;
   excluded: readonly IMarkType[];
   checkAttrs(attrs: Record<string, unknown>): void;
   excludes(other: IMarkType): boolean;

--- a/packages/core/document/src/lib/entities/Node.ts
+++ b/packages/core/document/src/lib/entities/Node.ts
@@ -315,7 +315,7 @@ export class Node implements INode {
   }
 
   resolve(pos: number): ResolvedPos {
-    return this.resolveNoCache(pos);
+    return ResolvedPos.resolveCached(this, pos);
   }
 
   replace(from: number, to: number, slice: ISlice): Node {

--- a/packages/core/document/src/lib/interfaces/SchemaSpec.ts
+++ b/packages/core/document/src/lib/interfaces/SchemaSpec.ts
@@ -20,6 +20,7 @@ export interface MarkSpec {
   attrs?: Record<string, AttributeSpec>;
   excludes?: string;
   group?: string;
+  inclusive?: boolean;
 }
 
 export interface AttributeSpec {

--- a/packages/core/document/src/lib/value-objects/MarkType.ts
+++ b/packages/core/document/src/lib/value-objects/MarkType.ts
@@ -10,6 +10,7 @@ export class MarkType implements IMarkType {
   readonly schema: unknown;
   readonly spec: MarkSpec;
   readonly attrs: Record<string, Attribute>;
+  inclusive?: boolean;
   excluded: readonly IMarkType[] = [];
   rank = 0;
 
@@ -21,6 +22,7 @@ export class MarkType implements IMarkType {
     this.name = name;
     this.schema = schema;
     this.spec = spec;
+    this.inclusive = spec.inclusive;
     this.attrs = {};
 
     if (spec.attrs) {

--- a/packages/core/document/src/lib/value-objects/ResolvedPos.spec.ts
+++ b/packages/core/document/src/lib/value-objects/ResolvedPos.spec.ts
@@ -2,7 +2,16 @@ import { Fragment } from '../entities/Fragment';
 import { Node } from '../entities/Node';
 import { ResolvedPos } from './ResolvedPos';
 import { TextNode } from '../entities/TextNode';
-import { createMockNode, paragraphType, textType } from '../../testing';
+import {
+  boldMarkType,
+  createMark,
+  createMarkType,
+  createMockNode,
+  defaultMarkSpec,
+  defaultMockSchema,
+  paragraphType,
+  textType,
+} from '../../testing';
 
 const path: (Node | number)[] = [];
 
@@ -196,6 +205,18 @@ describe('ResolvedPos', () => {
 
       expect(resolvedPos.before(1)).toBe(0);
     });
+
+    it('given depth equals this.depth + 1, returns pos', () => {
+      const childNode = createMockNode();
+      const rootNode = new Node(
+        createMockNode().type,
+        {},
+        Fragment.from([childNode])
+      );
+      const resolvedPos = ResolvedPos.resolve(rootNode, 0);
+
+      expect(resolvedPos.before(resolvedPos.depth + 1)).toBe(resolvedPos.pos);
+    });
   });
 
   describe('after', () => {
@@ -215,6 +236,18 @@ describe('ResolvedPos', () => {
       );
 
       expect(resolvedPos.after(1)).toBe(2);
+    });
+
+    it('given depth equals this.depth + 1, returns pos', () => {
+      const childNode = createMockNode();
+      const rootNode = new Node(
+        createMockNode().type,
+        {},
+        Fragment.from([childNode])
+      );
+      const resolvedPos = ResolvedPos.resolve(rootNode, 0);
+
+      expect(resolvedPos.after(resolvedPos.depth + 1)).toBe(resolvedPos.pos);
     });
   });
 
@@ -429,5 +462,211 @@ describe('ResolvedPos', () => {
 
       expect(resolvedPos?.nodeBefore).toBeNull();
     });
+  });
+
+  describe('posAtIndex', () => {
+    it('given index 0 and default depth, returns start of first child', () => {
+      const firstNode = createMockNode();
+      const secondNode = createMockNode();
+      const rootNode = new Node(
+        createMockNode().type,
+        {},
+        Fragment.from([firstNode, secondNode])
+      );
+      const resolvedPos = ResolvedPos.resolve(rootNode, 0);
+
+      expect(resolvedPos.posAtIndex(0)).toBe(0);
+    });
+
+    it('given index 1 and default depth, returns start of second child', () => {
+      const firstNode = createMockNode();
+      const secondNode = createMockNode();
+      const rootNode = new Node(
+        createMockNode().type,
+        {},
+        Fragment.from([firstNode, secondNode])
+      );
+      const resolvedPos = ResolvedPos.resolve(rootNode, 0);
+
+      expect(resolvedPos.posAtIndex(1)).toBe(firstNode.nodeSize);
+    });
+
+    it('given explicit depth, returns position at that depth', () => {
+      const childNode = createMockNode();
+      const paragraphNode = new Node(
+        paragraphType,
+        {},
+        Fragment.from([childNode])
+      );
+      const rootNode = new Node(
+        createMockNode().type,
+        {},
+        Fragment.from([paragraphNode])
+      );
+      const resolvedPos = ResolvedPos.resolve(rootNode, 1);
+
+      expect(resolvedPos.posAtIndex(0, 1)).toBe(1);
+    });
+  });
+
+  describe('marks', () => {
+    it('given empty parent, returns Mark.none', () => {
+      const rootNode = createMockNode();
+      const resolvedPos = ResolvedPos.resolve(rootNode, 0);
+
+      expect(resolvedPos.marks()).toEqual([]);
+    });
+
+    it('given cursor inside text node, returns text node marks', () => {
+      const mark = createMark(boldMarkType, { color: 'black' });
+      const textNode = new TextNode(textType, {}, 'hello', [mark]);
+      const rootNode = new Node(
+        paragraphType,
+        {},
+        Fragment.from([textNode]),
+        []
+      );
+      const resolvedPos = ResolvedPos.resolve(rootNode, 2);
+
+      expect(resolvedPos.marks()).toEqual([mark]);
+    });
+    it('given cursor between nodes, returns left node marks', () => {
+      const mark = createMark(boldMarkType, {});
+      const textNode1 = new TextNode(textType, {}, 'hello', [mark]);
+      const textNode2 = new TextNode(textType, {}, 'world', []);
+      const para = new Node(
+        paragraphType,
+        {},
+        Fragment.from([textNode1, textNode2]),
+        []
+      );
+      const rootNode = new Node(paragraphType, {}, Fragment.from([para]), []);
+      const resolvedPos = ResolvedPos.resolve(rootNode, 6);
+
+      expect(resolvedPos.marks()).toEqual([mark]);
+    });
+    it('given cursor between nodes with inclusive=false mark absent on right, excludes that mark', () => {
+      const markType = createMarkType('bold', defaultMockSchema, {
+        ...defaultMarkSpec,
+        inclusive: false,
+      });
+      const mark = createMark(markType, {});
+      const textNode1 = new TextNode(textType, {}, 'hello', [mark]);
+      const textNode2 = new TextNode(textType, {}, 'world', []);
+      const para = new Node(
+        paragraphType,
+        {},
+        Fragment.from([textNode1, textNode2]),
+        []
+      );
+      const rootNode = new Node(paragraphType, {}, Fragment.from([para]), []);
+      const resolvedPos = ResolvedPos.resolve(rootNode, 6);
+
+      expect(resolvedPos.marks()).toEqual([]);
+    });
+    it('given cursor at start of parent (no left node), returns right node marks', () => {
+      const mark = createMark(boldMarkType, {});
+      const textNode = new TextNode(textType, {}, 'hello', [mark]);
+      const para = new Node(paragraphType, {}, Fragment.from([textNode]), []);
+      const rootNode = new Node(paragraphType, {}, Fragment.from([para]), []);
+      const resolvedPos = ResolvedPos.resolve(rootNode, 1);
+
+      expect(resolvedPos.marks()).toEqual([mark]);
+    });
+  });
+
+  describe('marksAcross', () => {
+    it('given no node after position, returns null', () => {
+      const textNode = new TextNode(textType, {}, 'hello', []);
+      const para = new Node(paragraphType, {}, Fragment.from([textNode]), []);
+      const rootNode = new Node(paragraphType, {}, Fragment.from([para]), []);
+      const $from = ResolvedPos.resolve(rootNode, 7);
+      const $end = ResolvedPos.resolve(rootNode, 7);
+
+      expect($from.marksAcross($end)).toBeNull();
+    });
+
+    it('given non-inline node after position, returns null', () => {
+      const child = new Node(paragraphType, {});
+      const rootNode = new Node(paragraphType, {}, Fragment.from([child]), []);
+      const $from = ResolvedPos.resolve(rootNode, 0);
+      const $end = ResolvedPos.resolve(rootNode, 0);
+
+      expect($from.marksAcross($end)).toBeNull();
+    });
+
+    it('given inline node after, returns its marks', () => {
+      const mark = createMark(boldMarkType, {});
+      const textNode = new TextNode(textType, {}, 'hello', [mark]);
+      const para = new Node(paragraphType, {}, Fragment.from([textNode]), []);
+      const rootNode = new Node(paragraphType, {}, Fragment.from([para]), []);
+      const $from = ResolvedPos.resolve(rootNode, 1);
+      const $end = ResolvedPos.resolve(rootNode, 1);
+
+      expect($from.marksAcross($end)).toEqual([mark]);
+    });
+
+    it('given inclusive=false mark absent at $end, excludes that mark', () => {
+      const markType = createMarkType('bold', defaultMockSchema, {
+        ...defaultMarkSpec,
+        inclusive: false,
+      });
+      markType.inclusive = false;
+      const mark = createMark(markType, {});
+      const textNode1 = new TextNode(textType, {}, 'hello', [mark]);
+      const textNode2 = new TextNode(textType, {}, 'world', []);
+      const para = new Node(
+        paragraphType,
+        {},
+        Fragment.from([textNode1, textNode2]),
+        []
+      );
+      const rootNode = new Node(paragraphType, {}, Fragment.from([para]), []);
+      const $from = ResolvedPos.resolve(rootNode, 1);
+      const $end = ResolvedPos.resolve(rootNode, 7);
+
+      expect($from.marksAcross($end)).toEqual([]);
+    });
+  });
+
+  describe('resolveCached', () => {
+    it('given same doc and pos, returns same reference', () => {
+  const childNode = createMockNode();
+  const rootNode = new Node(
+    createMockNode().type,
+    {},
+    Fragment.from([childNode])
+  );
+
+  const first = ResolvedPos.resolveCached(rootNode, 0);
+  const second = ResolvedPos.resolveCached(rootNode, 0);
+
+  expect(first).toBe(second);
+});
+
+it('given different pos, returns different instance', () => {
+  const childNode = createMockNode();
+  const rootNode = new Node(
+    createMockNode().type,
+    {},
+    Fragment.from([childNode])
+  );
+
+  const first = ResolvedPos.resolveCached(rootNode, 0);
+  const second = ResolvedPos.resolveCached(rootNode, 1);
+
+  expect(first).not.toBe(second);
+});
+
+it('given different doc, returns different instance', () => {
+  const childNode = createMockNode();
+  const rootNode1 = new Node(createMockNode().type, {}, Fragment.from([childNode]));
+  const rootNode2 = new Node(createMockNode().type, {}, Fragment.from([childNode]));
+
+  const first = ResolvedPos.resolveCached(rootNode1, 0);
+  const second = ResolvedPos.resolveCached(rootNode2, 0);
+
+  expect(first).not.toBe(second);
+});
   });
 });

--- a/packages/core/document/src/lib/value-objects/ResolvedPos.ts
+++ b/packages/core/document/src/lib/value-objects/ResolvedPos.ts
@@ -1,3 +1,4 @@
+import { IMark } from '../contracts';
 import type { INode } from '../contracts/INode';
 
 export class ResolvedPos {
@@ -95,6 +96,8 @@ export class ResolvedPos {
       throw new Error('There is no position before the top-level node');
     }
 
+    if (resolvedDepth === this.depth + 1) return this.pos;
+
     return this.path[resolvedDepth * 3 - 1] as number;
   }
 
@@ -103,6 +106,8 @@ export class ResolvedPos {
     if (resolvedDepth === 0) {
       throw new Error('There is no position after the top-level node');
     }
+
+    if (resolvedDepth === this.depth + 1) return this.pos;
 
     return (
       (this.path[resolvedDepth * 3 - 1] as number) +
@@ -137,6 +142,76 @@ export class ResolvedPos {
 
   min(other: ResolvedPos): ResolvedPos {
     return this.pos < other.pos ? this : other;
+  }
+
+  marksAcross($end: ResolvedPos): readonly IMark[] | null {
+    const after = this.parent.maybeChild(this.index());
+    if (!after || !after.isInline) return null;
+
+    let marks: readonly IMark[] = after.marks;
+    const next = $end.parent.maybeChild($end.index());
+    for (let i = 0; i < marks.length; i++) {
+      if (
+        marks[i].type.inclusive === false &&
+        (!next || !marks[i].isInSet(next.marks))
+      ) {
+        marks = marks[i--].removeFromSet(marks);
+      }
+    }
+    return marks;
+  }
+
+  marks(): readonly IMark[] {
+    const parent = this.parent;
+    const index = this.index();
+
+    if (parent.content.size === 0) return [];
+    if (this.textOffset) return parent.child(index).marks;
+
+    let main = parent.maybeChild(index - 1);
+    let other = parent.maybeChild(index);
+
+    if (!main) {
+      const tmp = main;
+      main = other;
+      other = tmp;
+    }
+    if (!main) return [];
+
+    let marks: readonly IMark[] = main.marks;
+    for (let i = 0; i < marks.length; i++) {
+      if (
+        marks[i].type.inclusive === false &&
+        (!other || !marks[i].isInSet(other.marks))
+      ) {
+        marks = marks[i--].removeFromSet(marks);
+      }
+    }
+    return marks;
+  }
+
+  posAtIndex(index: number, depth?: number | null): number {
+    const resolvedDepth = this.resolveDepth(depth);
+    let pos = this.start(resolvedDepth);
+    for (let i = 0; i < index; i++) {
+      pos += (this.node(resolvedDepth).content.child(i) as INode).nodeSize;
+    }
+    return pos;
+  }
+
+  static resolveCached(doc: INode, pos: number): ResolvedPos {
+    let cache = resolveCache.get(doc);
+    if (cache) {
+      for (let i = 0; i < cache.elts.length; i++) {
+        const elt = cache.elts[i];
+        if (elt.pos === pos) return elt;
+      }
+    } else {
+      resolveCache.set(doc, (cache = new ResolveCache()));
+    }
+    const result = (cache.elts[cache.i] = ResolvedPos.resolve(doc, pos));
+    cache.i = (cache.i + 1) % resolveCacheSize;
+    return result;
   }
 
   equals(other: ResolvedPos): boolean {
@@ -175,3 +250,10 @@ export class ResolvedPos {
     }
   }
 }
+
+class ResolveCache {
+  elts: ResolvedPos[] = [];
+  i = 0;
+}
+const resolveCacheSize = 12;
+const resolveCache = new WeakMap<INode, ResolveCache>();


### PR DESCRIPTION
… resolveCached

- Add MarkSpec.inclusive?: boolean to SchemaSpec interface
- Add inclusive?: boolean to IMarkType interface
- Add inclusive field to MarkType with spec assignment in constructor
- Implement ResolvedPos.posAtIndex()
- Implement ResolvedPos.marks() with inclusive flag support
- Implement ResolvedPos.marksAcross() with inclusive flag support
- Implement ResolvedPos.resolveCached() with WeakMap-based ring cache
- Fix ResolvedPos.before() and after() — add depth == this.depth + 1 case
- Fix marks() swap logic for cursor at start of parent
- Update Node.resolve() to use resolveCached instead of resolveNoCache

Issue #59