### PR TITLE
feat(document): implement ResolvedPos.blockRange

### DIFF
--- a/packages/core/document/src/lib/contracts/IResolvedPos.ts
+++ b/packages/core/document/src/lib/contracts/IResolvedPos.ts
@@ -1,3 +1,4 @@
+import type { IMark } from './IMark';
 import type { INode } from './INode';
 
 export interface IResolvedPos {
@@ -15,9 +16,12 @@ export interface IResolvedPos {
   equals(other: IResolvedPos): boolean;
   index(depth?: number | null): number;
   indexAfter(depth?: number | null): number;
+  marks(): readonly IMark[];
+  marksAcross($end: IResolvedPos): readonly IMark[] | null
   max(other: IResolvedPos): IResolvedPos;
   min(other: IResolvedPos): IResolvedPos;
   node(depth?: number | null): INode;
+  posAtIndex(index: number, depth?: number | null): number 
   sameParent(other: IResolvedPos): boolean;
   sharedDepth(pos: number): number;
   start(depth?: number | null): number;

--- a/packages/core/document/src/lib/value-objects/MarkType.spec.ts
+++ b/packages/core/document/src/lib/value-objects/MarkType.spec.ts
@@ -76,7 +76,7 @@ describe('MarkType', () => {
         defaultMarkSpec
       );
       const markType2 = createMarkType('strong', defaultMockSchema, {
-        attrs: { color: 'blue' },
+        attrs: { color: { default: 'blue' } },
       });
 
       expect(markType1.equals(markType2)).toBe(true);
@@ -89,7 +89,7 @@ describe('MarkType', () => {
         defaultMarkSpec
       );
       const markType2 = createMarkType('em', defaultMockSchema, {
-        attrs: { color: 'blue' },
+        attrs: { color: { default: 'blue' } },
       });
 
       expect(markType1.equals(markType2)).toBe(false);

--- a/packages/core/document/src/lib/value-objects/NodeRange.ts
+++ b/packages/core/document/src/lib/value-objects/NodeRange.ts
@@ -1,10 +1,9 @@
-import { Node } from '../entities/Node';
-import { ResolvedPos } from './ResolvedPos';
+import { INode, IResolvedPos } from '../contracts';
 
 export class NodeRange {
   constructor(
-    public readonly $from: ResolvedPos,
-    public readonly $to: ResolvedPos,
+    public readonly $from: IResolvedPos,
+    public readonly $to: IResolvedPos,
     public readonly depth: number
   ) {
     this.validateParameter($from, '$from');
@@ -20,8 +19,8 @@ export class NodeRange {
     return this.$to.after(this.depth + 1);
   }
 
-  get parent(): Node {
-    return this.$from.node(this.depth) as Node;
+  get parent(): INode {
+    return this.$from.node(this.depth);
   }
 
   get startIndex(): number {

--- a/packages/core/document/src/lib/value-objects/ResolvedPos.spec.ts
+++ b/packages/core/document/src/lib/value-objects/ResolvedPos.spec.ts
@@ -1,6 +1,7 @@
 import { Fragment } from '../entities/Fragment';
 import { Node } from '../entities/Node';
 import { ResolvedPos } from './ResolvedPos';
+import { NodeRange } from './NodeRange';
 import { TextNode } from '../entities/TextNode';
 import {
   boldMarkType,
@@ -631,42 +632,134 @@ describe('ResolvedPos', () => {
 
   describe('resolveCached', () => {
     it('given same doc and pos, returns same reference', () => {
-  const childNode = createMockNode();
-  const rootNode = new Node(
-    createMockNode().type,
-    {},
-    Fragment.from([childNode])
-  );
+      const childNode = createMockNode();
+      const rootNode = new Node(
+        createMockNode().type,
+        {},
+        Fragment.from([childNode])
+      );
 
-  const first = ResolvedPos.resolveCached(rootNode, 0);
-  const second = ResolvedPos.resolveCached(rootNode, 0);
+      const first = ResolvedPos.resolveCached(rootNode, 0);
+      const second = ResolvedPos.resolveCached(rootNode, 0);
 
-  expect(first).toBe(second);
-});
+      expect(first).toBe(second);
+    });
 
-it('given different pos, returns different instance', () => {
-  const childNode = createMockNode();
-  const rootNode = new Node(
-    createMockNode().type,
-    {},
-    Fragment.from([childNode])
-  );
+    it('given different pos, returns different instance', () => {
+      const childNode = createMockNode();
+      const rootNode = new Node(
+        createMockNode().type,
+        {},
+        Fragment.from([childNode])
+      );
 
-  const first = ResolvedPos.resolveCached(rootNode, 0);
-  const second = ResolvedPos.resolveCached(rootNode, 1);
+      const first = ResolvedPos.resolveCached(rootNode, 0);
+      const second = ResolvedPos.resolveCached(rootNode, 1);
 
-  expect(first).not.toBe(second);
-});
+      expect(first).not.toBe(second);
+    });
 
-it('given different doc, returns different instance', () => {
-  const childNode = createMockNode();
-  const rootNode1 = new Node(createMockNode().type, {}, Fragment.from([childNode]));
-  const rootNode2 = new Node(createMockNode().type, {}, Fragment.from([childNode]));
+    it('given different doc, returns different instance', () => {
+      const childNode = createMockNode();
+      const rootNode1 = new Node(
+        createMockNode().type,
+        {},
+        Fragment.from([childNode])
+      );
+      const rootNode2 = new Node(
+        createMockNode().type,
+        {},
+        Fragment.from([childNode])
+      );
 
-  const first = ResolvedPos.resolveCached(rootNode1, 0);
-  const second = ResolvedPos.resolveCached(rootNode2, 0);
+      const first = ResolvedPos.resolveCached(rootNode1, 0);
+      const second = ResolvedPos.resolveCached(rootNode2, 0);
 
-  expect(first).not.toBe(second);
-});
+      expect(first).not.toBe(second);
+    });
+  });
+
+  describe('blockRange', () => {
+    it('given both positions in same textblock, returns NodeRange for that textblock', () => {
+      const textNode = new TextNode(textType, {}, 'hello');
+      const para = new Node(paragraphType, {}, Fragment.from([textNode]), []);
+      const rootNode = new Node(paragraphType, {}, Fragment.from([para]), []);
+      const $from = ResolvedPos.resolve(rootNode, 2);
+      const $to = ResolvedPos.resolve(rootNode, 4);
+
+      const range = $from.blockRange($to);
+
+      expect(range).toBeInstanceOf(NodeRange);
+      expect(range?.depth).toBe(1);
+    });
+
+    it('given positions in different blocks, returns NodeRange at shared ancestor depth', () => {
+      const para1 = new Node(paragraphType, {});
+      const para2 = new Node(paragraphType, {});
+      const rootNode = new Node(
+        paragraphType,
+        {},
+        Fragment.from([para1, para2]),
+        []
+      );
+      const $from = ResolvedPos.resolve(rootNode, 0);
+      const $to = ResolvedPos.resolve(
+        rootNode,
+        para1.nodeSize + para2.nodeSize
+      );
+
+      const range = $from.blockRange($to);
+
+      expect(range).toBeInstanceOf(NodeRange);
+      expect(range?.depth).toBe(0);
+    });
+
+    it('given other.pos < this.pos, returns same range as swapped call', () => {
+      const para1 = new Node(paragraphType, {});
+      const para2 = new Node(paragraphType, {});
+      const rootNode = new Node(
+        paragraphType,
+        {},
+        Fragment.from([para1, para2]),
+        []
+      );
+      const $from = ResolvedPos.resolve(rootNode, 0);
+      const $to = ResolvedPos.resolve(rootNode, para1.nodeSize);
+
+      const rangeForward = $from.blockRange($to);
+      const rangeBackward = $to.blockRange($from);
+
+      expect(rangeForward?.depth).toBe(rangeBackward?.depth);
+    });
+
+    it('given collapsed range, returns NodeRange', () => {
+      const para = new Node(paragraphType, {});
+      const rootNode = new Node(paragraphType, {}, Fragment.from([para]), []);
+      const $pos = ResolvedPos.resolve(rootNode, 1);
+
+      const range = $pos.blockRange($pos);
+
+      expect(range).toBeInstanceOf(NodeRange);
+    });
+
+    it('given pred that accepts the node, returns NodeRange', () => {
+      const para = new Node(paragraphType, {});
+      const rootNode = new Node(paragraphType, {}, Fragment.from([para]), []);
+      const $pos = ResolvedPos.resolve(rootNode, 1);
+
+      const range = $pos.blockRange($pos, () => true);
+
+      expect(range).toBeInstanceOf(NodeRange);
+    });
+
+    it('given pred that rejects all nodes, returns null', () => {
+      const para = new Node(paragraphType, {});
+      const rootNode = new Node(paragraphType, {}, Fragment.from([para]), []);
+      const $pos = ResolvedPos.resolve(rootNode, 0);
+
+      const range = $pos.blockRange($pos, () => false);
+
+      expect(range).toBeNull();
+    });
   });
 });

--- a/packages/core/document/src/lib/value-objects/ResolvedPos.ts
+++ b/packages/core/document/src/lib/value-objects/ResolvedPos.ts
@@ -1,5 +1,5 @@
-import { IMark } from '../contracts';
-import type { INode } from '../contracts/INode';
+import type { INode, IMark } from '../contracts';
+import { NodeRange } from './NodeRange';
 
 export class ResolvedPos {
   constructor(
@@ -99,6 +99,25 @@ export class ResolvedPos {
     if (resolvedDepth === this.depth + 1) return this.pos;
 
     return this.path[resolvedDepth * 3 - 1] as number;
+  }
+
+  blockRange(
+    other: ResolvedPos = this,
+    pred?: (node: INode) => boolean
+  ): NodeRange | null {
+    if (other.pos < this.pos) return other.blockRange(this, pred);
+    for (
+      let d =
+        this.depth -
+        (this.parent.inlineContent || this.pos == other.pos ? 1 : 0);
+      d >= 0;
+      d--
+    ) {
+      if (other.pos <= this.end(d) && (!pred || pred(this.node(d)))) {
+        return new NodeRange(this, other, d);
+      }
+    }
+    return null;
   }
 
   after(depth?: number | null): number {


### PR DESCRIPTION
- Add INodeRange interface to contracts
- Add blockRange() to IResolvedPos interface
- Update NodeRange to use IResolvedPos and INode
- Add marks(), marksAcross(), posAtIndex() to IResolvedPos
- Implement ResolvedPos.blockRange()

Issue #60