### PR TITLE
feat(document): implement Attribute value object

### DIFF
--- a/packages/core/document/src/lib/interfaces/SchemaSpec.ts
+++ b/packages/core/document/src/lib/interfaces/SchemaSpec.ts
@@ -25,5 +25,5 @@ export interface MarkSpec {
 
 export interface AttributeSpec {
   default?: unknown;
-  validate?: (value: unknown) => void;
+  validate?: string | ((value: unknown) => void);
 }

--- a/packages/core/document/src/lib/value-objects/Attribute.spec.ts
+++ b/packages/core/document/src/lib/value-objects/Attribute.spec.ts
@@ -34,4 +34,35 @@ describe('Attribute', () => {
       expect(attribute.isRequired).toBe(true);
     });
   });
+
+  describe('validate', () => {
+    describe('given string "number" and a non-number value', () => {
+      it('throws RangeError', () => {
+        const attribute = new Attribute({ validate: 'number' });
+
+        expect(() => attribute.validate?.('hello')).toThrow(RangeError);
+      });
+    });
+
+    describe('given string "number" and a number value', () => {
+      it('does not throw', () => {
+        const attribute = new Attribute({ validate: 'number' });
+        expect(() => attribute.validate?.(42)).not.toThrow();
+      });
+    });
+
+    describe('given string "null" and null value', () => {
+      it('does not throw', () => {
+        const attribute = new Attribute({ validate: 'null' });
+        expect(() => attribute.validate?.(null)).not.toThrow();
+      });
+    });
+
+    describe('given string "number|string" and a string value', () => {
+      it('does not throw', () => {
+        const attribute = new Attribute({ validate: 'number|string' });
+        expect(() => attribute.validate?.('hello')).not.toThrow();
+      });
+    });
+  });
 });

--- a/packages/core/document/src/lib/value-objects/Attribute.ts
+++ b/packages/core/document/src/lib/value-objects/Attribute.ts
@@ -1,10 +1,23 @@
-import { AttributeSpec } from "../interfaces/SchemaSpec";
+import { AttributeSpec } from '../interfaces/SchemaSpec';
 
 export class Attribute {
   readonly hasDefault: boolean;
+  readonly validate: ((value: unknown) => void) | undefined;
+
   constructor(public spec: AttributeSpec) {
     this.validateParameter('spec', spec);
     this.hasDefault = Object.prototype.hasOwnProperty.call(spec, 'default');
+
+    if (typeof spec.validate === 'string') {
+      const types = spec.validate.split('|');
+      this.validate = (value: unknown) => {
+        const typeName = value === null ? 'null' : typeof value;
+        if (!types.includes(typeName))
+          throw new RangeError(`Expected ${types}, got ${typeName}`);
+      };
+    } else {
+      this.validate = spec.validate
+    }
   }
 
   get isRequired(): boolean {


### PR DESCRIPTION
- Add Attribute class with hasDefault, isRequired, and validate
- Support string-based type validation with pipe-separated types
- Handle null value type checking via 'null' type name
- Add guard for null/undefined spec

Issue #81