### PR TITLE
feat(document): implement Node.children getter

### DIFF
--- a/packages/core/document/src/lib/contracts/INode.ts
+++ b/packages/core/document/src/lib/contracts/INode.ts
@@ -10,6 +10,7 @@ import { NodeJSON } from './types/NodeJSON';
 export interface INode {
   readonly attrs: Record<string, unknown>;
   readonly childCount: number;
+  readonly children: INode[];
   readonly content: IFragment;
   readonly firstChild: INode | undefined;
   readonly inlineContent: boolean | null;

--- a/packages/core/document/src/lib/entities/Node.spec.ts
+++ b/packages/core/document/src/lib/entities/Node.spec.ts
@@ -26,6 +26,7 @@ import {
   createSchemaSpec,
   createMarkSpec,
 } from '../../testing';
+import { Fragment } from './Fragment';
 
 describe('Node', () => {
   describe('constructor', () => {
@@ -838,6 +839,24 @@ describe('Node', () => {
         });
 
         expect(visited).toEqual([inner1, inner2]);
+      });
+    });
+  });
+
+  describe('children', () => {
+    describe('given node with no content', () => {
+      it('returns empty array', () => {
+        const parent = new Node(paragraphType, {});
+        expect(parent.children).toEqual([])
+      });
+    });
+
+    describe('given node with children', () => {
+      it('returns array of child nodes', () => {
+        const child1 = new TextNode(textType, {}, 'Hello');
+        const child2 = new TextNode(textType, {}, 'world');
+        const parent = new Node(paragraphType, {}, Fragment.from([child1, child2]));
+        expect(parent.children).toEqual([child1, child2])
       });
     });
   });

--- a/packages/core/document/src/lib/entities/Node.ts
+++ b/packages/core/document/src/lib/entities/Node.ts
@@ -68,6 +68,10 @@ export class Node implements INode {
     return this.content.childCount;
   }
 
+  get children(): INode[] {
+    return this.content.toArray();
+  }
+
   get nodeSize(): number {
     if (this.type.isLeaf) {
       return 1;


### PR DESCRIPTION
- Add `children` getter to Node and INode interface. 
- Returns direct child nodes as INode[].

Closes #84