### PR TITLE
feat(document): Add linebreakReplacement field to Schema

### DIFF
--- a/packages/core/document/src/lib/interfaces/SchemaSpec.ts
+++ b/packages/core/document/src/lib/interfaces/SchemaSpec.ts
@@ -15,6 +15,7 @@ export interface NodeSpec {
   inline?: boolean;
   isolating?: boolean;
   leafText?: (node: INode) => string
+  linebreakReplacement?: boolean;
   marks?: string;
   whitespace?: 'normal' | 'pre';
 }

--- a/packages/core/document/src/lib/services/Schema.spec.ts
+++ b/packages/core/document/src/lib/services/Schema.spec.ts
@@ -149,6 +149,51 @@ describe('Schema', () => {
       expect(schema.topNodeType).toBe(schema.nodes.paragraph);
     });
 
+    it('given no node spec has linebreakReplacement, linebreakReplacement is null', () => {
+      const schema = new Schema({
+        nodes: createSchemaSpec(),
+      });
+
+      expect(schema.linebreakReplacement).toBeNull();
+    });
+
+    it('given one inline leaf node with linebreakReplacement true, linebreakReplacement returns that NodeType', () => {
+      const schema = new Schema({
+        nodes: createSchemaSpec({
+          br: { content: '', inline: true, linebreakReplacement: true },
+        }),
+      });
+
+      expect(schema.linebreakReplacement).toBe(schema.nodes['br']);
+    });
+
+    it('given two nodes with linebreakReplacement true, throws Multiple linebreak nodes defined', () => {
+      expect(
+        () =>
+          new Schema({
+            nodes: createSchemaSpec({
+              newline: {
+                content: '',
+                inline: true,
+                linebreakReplacement: true,
+              }, // eski, unutulmuş
+              br: { content: '', inline: true, linebreakReplacement: true }, // yeni, <br> için eklenen
+            }),
+          })
+      ).toThrow('Multiple linebreak nodes defined');
+    });
+
+    it('given a non-inline-leaf node with linebreakReplacement true, throws Linebreak replacement nodes must be inline leaf nodes', () => {
+      expect(
+        () =>
+          new Schema({
+            nodes: createSchemaSpec({
+              br: { linebreakReplacement: true }, // inline: true unutulmuş → block sayılıyor, <div> gibi davranıyor
+            }),
+          })
+      ).toThrow('Linebreak replacement nodes must be inline leaf nodes');
+    });
+
     describe('spec', () => {
       describe('given a schema constructed with a spec', () => {
         it('returns the original spec', () => {

--- a/packages/core/document/src/lib/services/Schema.ts
+++ b/packages/core/document/src/lib/services/Schema.ts
@@ -13,6 +13,7 @@ export class Schema {
   readonly nodes: Record<string, NodeType>;
   readonly marks: Record<string, MarkType>;
   readonly cached: Record<string, unknown> = {};
+  readonly linebreakReplacement: NodeType | null = null;
   readonly topNodeType: NodeType;
   readonly spec: SchemaSpec;
   readonly nodeFromJSON: (json: NodeJSON) => Node;
@@ -59,6 +60,16 @@ export class Schema {
 
       if (type.spec.marks === '') {
         type.markSet = [];
+      }
+
+      if (type.spec.linebreakReplacement) {
+        if (this.linebreakReplacement)
+          throw new RangeError('Multiple linebreak nodes defined');
+        if (!type.isInline || !type.isLeaf)
+          throw new RangeError(
+            'Linebreak replacement nodes must be inline leaf nodes'
+          );
+        this.linebreakReplacement = type;
       }
     }
 


### PR DESCRIPTION
- Add Schema.linebreakReplacement field defaulting to null
- Assign linebreakReplacement when a node spec marks linebreakReplacement true
- Throw when multiple node specs mark linebreakReplacement true
- Throw when a linebreakReplacement node is not inline and leaf

Closes #88