### PR TITLE
feat(document): Add NodeSpec and MarkSpec optional fields

### DIFF
--- a/packages/core/document/src/lib/interfaces/SchemaSpec.ts
+++ b/packages/core/document/src/lib/interfaces/SchemaSpec.ts
@@ -11,20 +11,28 @@ export interface NodeSpec {
   attrs?: Record<string, AttributeSpec>;
   code?: boolean;
   content?: string;
+  defining?: boolean;
+  definingAsContext?: boolean;
+  definingForContent?: boolean;
+  draggable?: boolean;
   group?: string;
   inline?: boolean;
   isolating?: boolean;
   leafText?: (node: INode) => string
   linebreakReplacement?: boolean;
   marks?: string;
+  selectable?: boolean;
+  toDebugString?: (node: INode) => string;
   whitespace?: 'normal' | 'pre';
 }
 
 export interface MarkSpec {
   attrs?: Record<string, AttributeSpec>;
+  code?: boolean;
   excludes?: string;
   group?: string;
   inclusive?: boolean;
+  spanning?: boolean;
 }
 
 export interface AttributeSpec {


### PR DESCRIPTION
- Add defining, definingAsContext, definingForContent, draggable, selectable, toDebugString to NodeSpec
- Add code, spanning to MarkSpec

Closes #90, #91, #92, #93, #94, #95, #96, #97