### PR TITLE
feat(document): Add OrderedMap support to Schema

### DIFF
--- a/packages/core/document/src/lib/interfaces/SchemaSpec.ts
+++ b/packages/core/document/src/lib/interfaces/SchemaSpec.ts
@@ -1,8 +1,9 @@
 import { INode } from "../contracts";
+import { OrderedMap } from "../value-objects/OrderedMap";
 
 export interface SchemaSpec {
-  nodes: Record<string, NodeSpec>;
-  marks?: Record<string, MarkSpec>;
+  nodes: Record<string, NodeSpec> | OrderedMap<NodeSpec>;
+  marks?: Record<string, MarkSpec> | OrderedMap<MarkSpec>;
   topNode?: string;
 }
 

--- a/packages/core/document/src/lib/services/Schema.spec.ts
+++ b/packages/core/document/src/lib/services/Schema.spec.ts
@@ -5,6 +5,7 @@ import { MarkType } from '../value-objects/MarkType';
 import { NodeType } from '../value-objects/NodeType';
 import { Schema } from './Schema';
 import { createSchemaSpec, createMarkSpec } from '../../testing';
+import { OrderedMap } from '../value-objects/OrderedMap';
 
 describe('Schema', () => {
   describe('constructor', () => {
@@ -192,6 +193,27 @@ describe('Schema', () => {
             }),
           })
       ).toThrow('Linebreak replacement nodes must be inline leaf nodes');
+    });
+
+    it('given nodes as an OrderedMap instance, registers the node types from it', () => {
+      const nodes = OrderedMap.from({
+        doc: { content: 'text*' },
+        text: {},
+      });
+
+      const schema = new Schema({ nodes });
+
+      expect(schema.nodes['text']).toBeDefined();
+      expect(schema.nodes['doc']).toBeDefined();
+    });
+
+    it('given marks as an OrderedMap instance, registers the mark types from it', () => {
+      const nodes = { doc: { content: 'text*' }, text: {} };
+      const marks = OrderedMap.from({ bold: {} });
+
+      const schema = new Schema({ nodes, marks });
+
+      expect(schema.marks['bold']).toBeDefined();
     });
 
     describe('spec', () => {

--- a/packages/core/document/src/lib/services/Schema.ts
+++ b/packages/core/document/src/lib/services/Schema.ts
@@ -8,6 +8,7 @@ import type { INode } from '../contracts/INode';
 import { MarkType } from '../value-objects/MarkType';
 import { NodeType } from '../value-objects/NodeType';
 import { NodeJSON } from '../contracts/types/NodeJSON';
+import { OrderedMap } from '../value-objects/OrderedMap';
 
 export class Schema {
   readonly nodes: Record<string, NodeType>;
@@ -26,19 +27,24 @@ export class Schema {
     this.validateParameter('nodes spec', spec.nodes);
     this.validateParameter('marks spec', spec.marks);
 
-    if (!spec.nodes['text']) {
+    const nodes = OrderedMap.from(spec.nodes);
+    const marks = OrderedMap.from(spec.marks ?? {});
+
+    if (!nodes.get('text')) {
       throw Error("Every schema needs a 'text' type");
     }
 
-    if (!spec.nodes['doc']) {
+    if (!nodes.get('doc')) {
       throw Error("Every schema needs a 'doc' type");
     }
 
-    if (spec.marks) {
-      const specs = Object.keys(spec.nodes).concat(Object.keys(spec.marks));
+    if (marks) {
+      const names: string[] = [];
+      nodes.forEach((name) => names.push(name));
+      marks.forEach((name) => names.push(name));
 
-      specs.forEach((item, index) => {
-        if (specs.indexOf(item) !== index) {
+      names.forEach((item, index) => {
+        if (names.indexOf(item) !== index) {
           throw Error(`${item} can not be both a node and a mark`);
         }
       });
@@ -47,7 +53,7 @@ export class Schema {
     this.nodes = {};
     this.marks = {};
 
-    this.populateRegistry(spec.nodes, spec.marks ?? {});
+    this.populateRegistry(nodes, marks);
 
     this.topNodeType = this.nodes[spec.topNode ?? 'doc'];
 
@@ -130,16 +136,17 @@ export class Schema {
   }
 
   private populateRegistry(
-    nodeSpec: Record<string, NodeSpec>,
-    markSpec: Record<string, MarkSpec>
+    nodeSpec: OrderedMap<NodeSpec>,
+    markSpec: OrderedMap<MarkSpec>
   ): void {
-    for (const [name, spec] of Object.entries(nodeSpec)) {
+    nodeSpec.forEach((name, spec) => {
       this.nodes[name] = new NodeType(name, this, spec);
-    }
+    });
 
-    Object.entries(markSpec).forEach(([name, spec], index) => {
+    let index = 0;
+    markSpec.forEach((name, spec) => {
       this.marks[name] = new MarkType(name, this, spec);
-      this.marks[name].rank = index;
+      this.marks[name].rank = index++;
       this.marks[name].excluded =
         spec.excludes === undefined ? [this.marks[name]] : [];
     });

--- a/packages/core/document/src/lib/value-objects/OrderedMap.spec.ts
+++ b/packages/core/document/src/lib/value-objects/OrderedMap.spec.ts
@@ -1,0 +1,39 @@
+import { OrderedMap } from './OrderedMap';
+
+describe('OrderedMap', () => {
+  describe('from', () => {
+    it('given a plain object, creates an OrderedMap instance', () => {
+      const map = OrderedMap.from({ a: 1 });
+      expect(map).toBeInstanceOf(OrderedMap);
+    });
+
+    it('given an existing OrderedMap instance, returns it as-is', () => {
+      const original = OrderedMap.from({ a: 1 });
+      const result = OrderedMap.from(original);
+      expect(result).toBe(original);
+    });
+  });
+
+  describe('get', () => {
+    it('given an existing key, returns its value', () => {
+      const map = OrderedMap.from({ a: 1 });
+      expect(map.get('a')).toBe(1);
+    });
+
+    it('given a missing key, returns undefined', () => {
+      const map = OrderedMap.from({ a: 1 });
+      expect(map.get('missing')).toBeUndefined();
+    });
+  });
+
+  describe('forEach', () => {
+    it('given a map with multiple entries, iterates in insertion order', () => {
+      const map = OrderedMap.from({ a: 1, b: 2 });
+      const seen: [string, number][] = [];
+
+      map.forEach((key, value) => seen.push([key, value]));
+
+      expect(seen).toEqual([['a', 1], ['b', 2]]);
+    });
+  });
+});

--- a/packages/core/document/src/lib/value-objects/OrderedMap.ts
+++ b/packages/core/document/src/lib/value-objects/OrderedMap.ts
@@ -1,0 +1,29 @@
+export class OrderedMap<T> {
+  private readonly content: readonly [string, T][];
+
+  private constructor(content: readonly [string, T][]) {
+    this.content = content;
+  }
+
+  static from<T>(map: Record<string, T> | OrderedMap<T>): OrderedMap<T> {
+    if (map instanceof OrderedMap) return map;
+
+    const content: [string, T][] = [];
+    for (const key in map) {
+      content.push([key, map[key]]);
+    }
+
+    return new OrderedMap<T>(content);
+  }
+
+  get(key: string): T | undefined {
+    const entry = this.content.find(([entryKey]) => entryKey === key);
+    return entry ? entry[1] : undefined;
+  }
+
+  forEach(fn: (key: string, value: T) => void): void {
+    for (const [key, value] of this.content) {
+      fn(key, value);
+    }
+  }
+}


### PR DESCRIPTION
- Add OrderedMap value object (from, get, forEach)
- Accept OrderedMap as alternative to Record for SchemaSpec.nodes/marks
- Normalize nodes/marks to OrderedMap in Schema constructor

Closes #98